### PR TITLE
do not raise error for async node

### DIFF
--- a/pyan/analyzer.py
+++ b/pyan/analyzer.py
@@ -811,7 +811,7 @@ class CallGraphVisitor(ast.NodeVisitor):
         or None if not applicable; and flavor is a Flavor, specifically one of
         FUNCTION, METHOD, STATICMETHOD or CLASSMETHOD."""
 
-        if not isinstance(ast_node, ast.FunctionDef):
+        if not isinstance(ast_node, (ast.AsyncFunctionDef , ast.FunctionDef)):
             raise TypeError("Expected ast.FunctionDef; got %s" % (type(ast_node)))
 
         # Visit decorators


### PR DESCRIPTION
Currently, an error is raised for asynchronous function. This is an easy fix