### PR TITLE
Resolve `from` imports

### DIFF
--- a/pyan/__init__.py
+++ b/pyan/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from typing import Union, List
 import io
 from glob import glob
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+addopts =
+    -rsxX
+    -vv
+
+    --cov-config=.coveragerc
+    --cov=pyan
+    --cov-report=html
+    --cov-report=term-missing:skip-covered
+    --no-cov-on-fail
+testpaths = tests/
+log_cli_level = ERROR
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+cache_dir = .cache

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,55 @@
+import logging
+from glob import glob
+import os
+import pytest
+
+from pyan.analyzer import CallGraphVisitor
+
+@pytest.fixture
+def callgraph():
+    filenames = glob(os.path.join(os.path.dirname(__file__), "test_code/**/*.py"), recursive=True)
+    v = CallGraphVisitor(filenames, logger=logging.getLogger())
+    return v
+
+
+def get_node(nodes, name):
+    filtered_nodes = [node for node in nodes if node.get_name() == name]
+    assert len(filtered_nodes) == 1, f"Node with name {name} should exist"
+    return filtered_nodes[0]
+
+def get_in_dict(node_dict, name):
+    return node_dict[get_node(node_dict.keys(), name)]
+
+
+
+def test_resolve_import_as(callgraph):
+    imports = get_in_dict(callgraph.uses_edges, "test_code.submodule2")
+    get_node(imports, "test_code.submodule1")
+    assert len(imports) == 1, "only one effective import"
+
+
+    imports = get_in_dict(callgraph.uses_edges, "test_code.submodule1")
+    get_node(imports, "test_code.subpackage1.submodule1.A")
+    get_node(imports, "test_code.subpackage1")
+
+
+def test_import_relative(callgraph):
+    imports = get_in_dict(callgraph.uses_edges, "test_code.subpackage1.submodule1")
+    get_node(imports, "test_code.submodule2.test_2")
+
+
+def test_resolve_use_in_class(callgraph):
+    uses = get_in_dict(callgraph.uses_edges, "test_code.subpackage1.submodule1.A.__init__")
+    get_node(uses, "test_code.submodule2.test_2")
+
+
+def test_resolve_use_in_function(callgraph):
+    uses = get_in_dict(callgraph.uses_edges, "test_code.submodule2.test_2")
+    get_node(uses, "test_code.submodule1.test_func1")
+    get_node(uses, "test_code.submodule1.test_func2")
+
+
+
+
+
+

--- a/tests/test_code/submodule1.py
+++ b/tests/test_code/submodule1.py
@@ -1,0 +1,23 @@
+from test_code.subpackage1 import A
+from test_code import subpackage1 as subpackage
+
+
+def test_func1(a):
+    return a
+
+def test_func2(a):
+    return a
+
+
+class B:
+
+    def __init__(self, k):
+        self.a = 1
+
+
+    def to_A(self):
+        return A(self)
+
+    def get_a_via_A(self):
+        return test_func1(self.to_A().b.a)
+

--- a/tests/test_code/submodule2.py
+++ b/tests/test_code/submodule2.py
@@ -1,0 +1,7 @@
+from . import submodule1
+import test_code.submodule1 as b
+
+A = 32
+
+def test_2(a):
+    return submodule1.test_func2(a) + A + b.test_func1(a)

--- a/tests/test_code/subpackage1/__init__.py
+++ b/tests/test_code/subpackage1/__init__.py
@@ -1,0 +1,3 @@
+from test_code.subpackage1.submodule1 import A
+
+__all__ = ["A"]

--- a/tests/test_code/subpackage1/submodule1.py
+++ b/tests/test_code/subpackage1/submodule1.py
@@ -1,0 +1,7 @@
+
+from ..submodule2 import test_2
+
+class A:
+
+    def __init__(self, b):
+        self.b = test_2(b)


### PR DESCRIPTION
This PR addresses import such as `from mod_x import func_y as func_z` and `from mod_x import mod_y`. Relative imports such as `from ..mod_x import mod_y` are not supported. However, relative imports are considered bad style and discouraged. It's probably not too much work to add this functionality.

As the package structure has to be known to resolve imports, this is done as a post-processing step relinking the modules.