### PR TITLE
Check if list of file globs matches at least one file

### DIFF
--- a/pyan/main.py
+++ b/pyan/main.py
@@ -80,6 +80,8 @@ def main():
     filenames = [fn2 for fn in args for fn2 in glob(fn)]
     if len(args) == 0:
         parser.error('Need one or more filenames to process')
+    if len(args) > 0 and len(filenames) == 0:
+        parser.error('No files found matching given glob: %s' % ' '.join(args))
 
     if options.nested_groups:
         options.grouped = True


### PR DESCRIPTION
When given glob does not match any files, pyan3 exits without telling
anything and generated an empty graph.

That might be confusing, when an incorrect file path is given. To avoid
confusion, added additional check if glob matches at least one file.

Now it works like this:

    > pyan3 --dot -f /tmp/graph.dot does/not/exist.py
    Usage: pyan3 FILENAME... [--dot|--tgf|--yed]

    pyan3: error: No files found matching given glob: does/not/exist.py