### PR TITLE
Fix visualize_pyan_architecture.sh

### DIFF
--- a/visualize_pyan_architecture.sh
+++ b/visualize_pyan_architecture.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo -ne "Pyan architecture: generating architecture.{dot,svg}\n"
-./pyan.py pyan/*.py --no-defines --uses --colored --annotate --dot -V >architecture.dot 2>architecture.log
+./pyan3 pyan/*.py --no-defines --uses --colored --annotate --dot -V >architecture.dot 2>architecture.log
 dot -Tsvg architecture.dot >architecture.svg


### PR DESCRIPTION
#### The script `visualize_pyan_architecture` called a old version of `pyan3` main script so it didn't work anymore.

#### I've changed to call  `pyan3`