### PR TITLE
Fix pip installation when wheel is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     # See
     #    http://setuptools.readthedocs.io/en/latest/setuptools.html
     #
-    setup_requires=[],
+    setup_requires=["wheel"],
     install_requires=[],
     provides=["pyan"],
 


### PR DESCRIPTION
# Installation error when `wheel` is not installed

## Scenario

### Pre condition

- wheel is not installed

### Steps

- Navigate to the source code root

- Install pyan3 from code using pip:

```bash
    pip install .
```

## Fix

- I've added the `wheel` package to the setup stage on `setup.py` so it will only be installed if the user wanted to install from code.