### PR TITLE
Trailing whitespace and shorter lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,3 @@ This Python 3 port, analyzer expansion, and additional refactoring by Juha Jeron
 # License
 
 [GPL v2](LICENSE.md), as per [comments here](https://ejrh.wordpress.com/2012/08/18/coloured-call-graphs/).
-

--- a/pyan/analyzer.py
+++ b/pyan/analyzer.py
@@ -474,7 +474,7 @@ class CallGraphVisitor(ast.NodeVisitor):
         # resolve relative imports 'None' such as "from . import foo"
         if node.module is None:
             self.logger.debug("ImportFrom (original) from %s import %s, %s:%s" % ('.' * node.level, [format_alias(x) for x in node.names], self.filename, node.lineno))
-            tgt_level = node.level 
+            tgt_level = node.level
             current_module_namespace = self.module_name.rsplit('.', tgt_level)[0]
             tgt_name = current_module_namespace
             self.logger.debug("ImportFrom (resolved): from %s import %s, %s:%s" % (tgt_name, [format_alias(x) for x in node.names], self.filename, node.lineno))
@@ -491,7 +491,7 @@ class CallGraphVisitor(ast.NodeVisitor):
             # pyan can handle Relative imports such as "from .mod import foo" and "from ..mod import foo"
             if node.level != 0:
                 self.logger.debug("ImportFrom (original): from %s import %s, %s:%s" % (node.module, [format_alias(x) for x in node.names], self.filename, node.lineno))
-                tgt_level = node.level 
+                tgt_level = node.level
                 current_module_namespace = self.module_name.rsplit('.', tgt_level)[0]
                 tgt_name = current_module_namespace + '.' + node.module
                 self.logger.debug("ImportFrom (resolved): from %s import %s, %s:%s" % (tgt_name, [format_alias(x) for x in node.names], self.filename, node.lineno))
@@ -1656,7 +1656,7 @@ class CallGraphVisitor(ast.NodeVisitor):
         # What about incoming uses edges? E.g. consider a lambda that is saved
         # in an instance variable, then used elsewhere. How do we want the
         # graph to look like in that case?
-        
+
         # BUG: resolve relative imports causes (RuntimeError: dictionary changed size during iteration)
         # temporary solution is adding list to force a copy of 'self.nodes'
         for name in list(self.nodes):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ from setuptools import setup
 
 # Name of the top-level package of the library.
 #
-# This is also the top level of its source tree, relative to the top-level project directory setup.py resides in.
+# This is also the top level of its source tree,
+# relative to the top-level project directory setup.py resides in.
 #
 libname = "pyan"
 
@@ -38,14 +39,18 @@ SHORTDESC = "Offline call graph generator for Python 3"
 
 # Long description for package homepage on PyPI
 #
-DESC = """Generate approximate call graphs for Python programs.
-
-Pyan takes one or more Python source files, performs a (rather superficial) static analysis, and constructs a directed graph of the objects in the combined source, and how they define or use each other. The graph can be output for rendering by GraphViz or yEd.
-"""
+DESC = (
+    'Generate approximate call graphs for Python programs.\n'
+    '\n'
+    'Pyan takes one or more Python source files, performs a '
+    '(rather superficial) static analysis, and constructs a directed graph of '
+    'the objects in the combined source, and how they define or '
+    'use each other. The graph can be output for rendering by GraphViz or yEd.')
 
 # Set up data files for packaging.
 #
-# Directories (relative to the top-level directory where setup.py resides) in which to look for data files.
+# Directories (relative to the top-level directory where setup.py resides) in
+# which to look for data files.
 datadirs = ()
 
 # File extensions to be considered as data files. (Literal, no wildcards.)
@@ -53,8 +58,10 @@ dataexts = (".py", ".ipynb", ".sh", ".lyx", ".tex", ".txt", ".pdf")
 
 # Standard documentation to detect (and package if it exists).
 #
-standard_docs = ["README", "LICENSE", "TODO", "CHANGELOG", "AUTHORS"]  # just the basename without file extension
-standard_doc_exts = [".md", ".rst", ".txt", ""]  # commonly .md for GitHub projects, but other projects may use .rst or .txt (or even blank).
+standard_docs = ["README", "LICENSE", "TODO", "CHANGELOG", "AUTHORS"]
+    # just the basename without file extension
+standard_doc_exts = [".md", ".rst", ".txt", ""]  # commonly .md for
+    # GitHub projects, but other projects may use .rst or .txt (or even blank).
 
 #########################################################
 # Init
@@ -62,12 +69,13 @@ standard_doc_exts = [".md", ".rst", ".txt", ""]  # commonly .md for GitHub proje
 
 # Gather user-defined data files
 #
-# http://stackoverflow.com/questions/13628979/setuptools-how-to-make-package-contain-extra-data-folder-and-all-folders-inside
+# https://stackoverflow.com/q/13628979/1959808
 #
 datafiles = []
 #getext = lambda filename: os.path.splitext(filename)[1]
 #for datadir in datadirs:
-#    datafiles.extend( [(root, [os.path.join(root, f) for f in files if getext(f) in dataexts])
+#    datafiles.extend( [(root, [os.path.join(root, f)
+#                       for f in files if getext(f) in dataexts])
 #                       for root, dirs, files in os.walk(datadir)] )
 
 # Add standard documentation (README et al.), if any, to data files
@@ -75,15 +83,17 @@ datafiles = []
 detected_docs = []
 for docname in standard_docs:
     for ext in standard_doc_exts:
-        filename = "".join((docname, ext))  # relative to the directory in which setup.py resides
+        filename = "".join((docname, ext))  # relative to the directory in
+            # which setup.py resides
         if os.path.isfile(filename):
             detected_docs.append(filename)
 datafiles.append(('.', detected_docs))
 
 # Extract __version__ from the package __init__.py
-# (since it's not a good idea to actually run __init__.py during the build process).
+# (since it's not a good idea to actually run __init__.py during the
+#  build process).
 #
-# http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
+# https://stackoverflow.com/q/2058802/1959808
 #
 init_py_path = os.path.join('pyan', '__init__.py')
 version = '0.0.unknown'
@@ -94,9 +104,17 @@ try:
                 version = ast.parse(line).body[0].value.s
                 break
         else:
-            print("WARNING: Version information not found in '%s', using placeholder '%s'" % (init_py_path, version), file=sys.stderr)
+            print((
+                "WARNING: Version information not found in "
+                "'{path}', using placeholder '{version}'").format(
+                    path=init_py_path, version=version),
+                file=sys.stderr)
 except FileNotFoundError:
-    print("WARNING: Could not find file '%s', using placeholder version information '%s'" % (init_py_path, version), file=sys.stderr)
+    print((
+        "WARNING: Could not find file '{path}', "
+        "using placeholder version information '{version}'").format(
+            path=init_py_path, version=version),
+        file=sys.stderr)
 
 #########################################################
 # Call setup()
@@ -114,7 +132,8 @@ setup(
 
     license="GPL 2.0",
 
-    # free-form text field; http://stackoverflow.com/questions/34994130/what-platforms-argument-to-setup-in-setup-py-does
+    # free-form text field;
+    # https://stackoverflow.com/q/34994130/1959808
     platforms=["Linux"],
 
     # See
@@ -125,7 +144,8 @@ setup(
     classifiers=["Development Status :: 4 - Beta",
                  "Environment :: Console",
                  "Intended Audience :: Developers",
-                 "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+                 ("License :: OSI Approved :: "
+                  "GNU General Public License v2 (GPLv2)"),
                  "Operating System :: POSIX :: Linux",
                  "Programming Language :: Python",
                  "Programming Language :: Python :: 3",
@@ -142,13 +162,16 @@ setup(
 
     # keywords for PyPI (in case you upload your project)
     #
-    # e.g. the keywords your project uses as topics on GitHub, minus "python" (if there)
+    # e.g. the keywords your project uses as topics on GitHub,
+    # minus "python" (if there)
     #
     keywords=["call-graph", "static-code-analysis"],
 
-    # Declare packages so that  python -m setup build  will copy .py files (especially __init__.py).
+    # Declare packages so that  python -m setup build  will copy .py files
+    # (especially __init__.py).
     #
-    # This **does not** automatically recurse into subpackages, so they must also be declared.
+    # This **does not** automatically recurse into subpackages,
+    # so they must also be declared.
     #
     packages=["pyan"],
 


### PR DESCRIPTION
Remove trailing whitespace from all files where it existed, and wrap lines to fit in an 80-character width.