### PR TITLE
Adding an extension for using pyan with sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Offline call graph generator for Python 3
 Pyan takes one or more Python source files, performs a (rather superficial) static analysis, and constructs a directed graph of the objects in the combined source, and how they define or use each other. The graph can be output for rendering by GraphViz or yEd.
 
 This project has 2 official repositories:
+
 - The original stable [davidfraser/pyan](https://github.com/davidfraser/pyan).
 - The development repository [Technologicat/pyan](https://github.com/Technologicat/pyan)
 
@@ -19,17 +20,17 @@ This project has 2 official repositories:
 
 [![Example output](graph0.png "Example: GraphViz rendering of Pyan output (click for .svg)")](graph0.svg)
 
-**Defines** relations are drawn with *dotted gray arrows*.
+**Defines** relations are drawn with _dotted gray arrows_.
 
-**Uses** relations are drawn with *black solid arrows*. Recursion is indicated by an arrow from a node to itself. [Mutual recursion](https://en.wikipedia.org/wiki/Mutual_recursion#Basic_examples) between nodes X and Y is indicated by a pair of arrows, one pointing from X to Y, and the other from Y to X.
+**Uses** relations are drawn with _black solid arrows_. Recursion is indicated by an arrow from a node to itself. [Mutual recursion](https://en.wikipedia.org/wiki/Mutual_recursion#Basic_examples) between nodes X and Y is indicated by a pair of arrows, one pointing from X to Y, and the other from Y to X.
 
 **Nodes** are always filled, and made translucent to clearly show any arrows passing underneath them. This is especially useful for large graphs with GraphViz's `fdp` filter. If colored output is not enabled, the fill is white.
 
-In **node coloring**, the [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) color model is used. The **hue** is determined by the *filename* the node comes from. The **lightness** is determined by *depth of namespace nesting*, with darker meaning more deeply nested. Saturation is constant. The spacing between different hues depends on the number of files analyzed; better results are obtained for fewer files.
+In **node coloring**, the [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) color model is used. The **hue** is determined by the _filename_ the node comes from. The **lightness** is determined by _depth of namespace nesting_, with darker meaning more deeply nested. Saturation is constant. The spacing between different hues depends on the number of files analyzed; better results are obtained for fewer files.
 
 **Groups** are filled with translucent gray to avoid clashes with any node color.
 
-The nodes can be **annotated** by *filename and source line number* information.
+The nodes can be **annotated** by _filename and source line number_ information.
 
 ## Note
 
@@ -37,11 +38,9 @@ The static analysis approach Pyan takes is different from running the code and s
 
 In Pyan3, the analyzer was ported from `compiler` ([good riddance](https://stackoverflow.com/a/909172)) to a combination of `ast` and `symtable`, and slightly extended.
 
-
 # Install
 
     pip install pyan3
-
 
 # Usage
 
@@ -71,9 +70,50 @@ from IPython.display import HTML
 HTML(pyan.create_callgraph(filenames="**/*.py", format="html"))
 ```
 
+#### Sphinx integration
+
+You can integrate callgraphs into Sphinx.
+Install graphviz (e.g. via `sudo apt-get install graphviz`) and modify `source/conf.py` so that
+
+```
+# modify extensions
+extensions = [
+  ...
+  "sphinx.ext.graphviz
+  "pyan.sphinx",
+]
+
+# add graphviz options
+graphviz_output_format = "svg"
+```
+
+Now, there is a callgraph directive which has all the options of the [graphviz directive](https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html)
+and in addition:
+
+- **:no-groups:** (boolean flag): do not group
+- **:no-defines:** (boolean flag): if to not draw edges that show which functions, methods and classes are defined by a class or module
+- **:no-uses:** (boolean flag): if to not draw edges that show how a function uses other functions
+- **:no-colors:** (boolean flag): if to not color in callgraph (default is coloring)
+- **:nested-grops:** (boolean flag): if to group by modules and submodules
+- **:annotated:** (boolean flag): annotate callgraph with file names
+- **:direction:** (string): "horizontal" or "vertical" callgraph
+- **:toctree:** (string): path to toctree (as used with autosummary) to link elements of callgraph to documentation (makes all nodes clickable)
+- **:zoomable:** (boolean flag): enables users to zoom and pan callgraph
+
+Example to create a callgraph for the function `pyan.create_callgraph` that is
+zoomable, is defined from left to right and links each node to the API documentation that
+was created at the toctree path `api`.
+
+````
+.. callgraph:: pyan.create_callgraph
+   :toctree: api
+   :zoomable:
+   :direction: horizontal
+```
+
 #### Troubleshooting
 
-If GraphViz says *trouble in init_rank*, try adding `-Gnewrank=true`, as in:
+If GraphViz says _trouble in init_rank_, try adding `-Gnewrank=true`, as in:
 
 `dot -Gnewrank=true -Tsvg myuses.dot >myuses.svg`
 
@@ -85,86 +125,85 @@ If the graph is visually unreadable due to too much detail, consider visualizing
 
 Currently Pyan always operates at the level of individual functions and methods; an option to visualize only relations between namespaces may (or may not) be added in a future version.
 
-
 # Features
 
-*Items tagged with ☆ are new in Pyan3.*
+_Items tagged with ☆ are new in Pyan3._
 
 **Graph creation**:
 
- - Nodes for functions and classes
- - Edges for defines
- - Edges for uses
-   - This includes recursive calls ☆
- - Grouping to represent defines, with or without nesting
- - Coloring of nodes by filename
-   - Unlimited number of hues ☆
+- Nodes for functions and classes
+- Edges for defines
+- Edges for uses
+  - This includes recursive calls ☆
+- Grouping to represent defines, with or without nesting
+- Coloring of nodes by filename
+  - Unlimited number of hues ☆
 
 **Analysis**:
 
- - Name lookup across the given set of files
- - Nested function definitions
- - Nested class definitions ☆
- - Nested attribute accesses like `self.a.b` ☆
- - Inherited attributes ☆
-   - Pyan3 looks up also in base classes when resolving attributes. In the old Pyan, calls to inherited methods used to be picked up by `contract_nonexistents()` followed by `expand_unknowns()`, but that often generated spurious uses edges (because the wildcard to `*.name` expands to `X.name` *for all* `X` that have an attribute called `name`.).
- - Resolution of `super()` based on the static type at the call site ☆
- - MRO is (statically) respected in looking up inherited attributes and `super()` ☆
- - Assignment tracking with lexical scoping
-   - E.g. if `self.a = MyFancyClass()`, the analyzer knows that any references to `self.a` point to `MyFancyClass`
-   - All binding forms are supported (assign, augassign, for, comprehensions, generator expressions, with) ☆
-     - Name clashes between `for` loop counter variables and functions or classes defined elsewhere no longer confuse Pyan.
- - `self` is defined by capturing the name of the first argument of a method definition, like Python does. ☆
- - Simple item-by-item tuple assignments like `x,y,z = a,b,c` ☆
- - Chained assignments `a = b = c` ☆
- - Local scope for lambda, listcomp, setcomp, dictcomp, genexpr ☆
-   - Keep in mind that list comprehensions gained a local scope (being treated like a function) only in Python 3. Thus, Pyan3, when applied to legacy Python 2 code, will give subtly wrong results if the code uses list comprehensions.
- - Source filename and line number annotation ☆
-   - The annotation is appended to the node label. If grouping is off, namespace is included in the annotation. If grouping is on, only source filename and line number information is included, because the group title already shows the namespace.
+- Name lookup across the given set of files
+- Nested function definitions
+- Nested class definitions ☆
+- Nested attribute accesses like `self.a.b` ☆
+- Inherited attributes ☆
+  - Pyan3 looks up also in base classes when resolving attributes. In the old Pyan, calls to inherited methods used to be picked up by `contract_nonexistents()` followed by `expand_unknowns()`, but that often generated spurious uses edges (because the wildcard to `*.name` expands to `X.name` _for all_ `X` that have an attribute called `name`.).
+- Resolution of `super()` based on the static type at the call site ☆
+- MRO is (statically) respected in looking up inherited attributes and `super()` ☆
+- Assignment tracking with lexical scoping
+  - E.g. if `self.a = MyFancyClass()`, the analyzer knows that any references to `self.a` point to `MyFancyClass`
+  - All binding forms are supported (assign, augassign, for, comprehensions, generator expressions, with) ☆
+    - Name clashes between `for` loop counter variables and functions or classes defined elsewhere no longer confuse Pyan.
+- `self` is defined by capturing the name of the first argument of a method definition, like Python does. ☆
+- Simple item-by-item tuple assignments like `x,y,z = a,b,c` ☆
+- Chained assignments `a = b = c` ☆
+- Local scope for lambda, listcomp, setcomp, dictcomp, genexpr ☆
+  - Keep in mind that list comprehensions gained a local scope (being treated like a function) only in Python 3. Thus, Pyan3, when applied to legacy Python 2 code, will give subtly wrong results if the code uses list comprehensions.
+- Source filename and line number annotation ☆
+  - The annotation is appended to the node label. If grouping is off, namespace is included in the annotation. If grouping is on, only source filename and line number information is included, because the group title already shows the namespace.
 
 ## TODO
 
- - Determine confidence of detected edges (probability that the edge is correct). Start with a binary system, with only values 1.0 and 0.0.
-   - A fully resolved reference to a name, based on lexical scoping, has confidence 1.0.
-   - A reference to an unknown name has confidence 0.0.
-   - Attributes:
-     - A fully resolved reference to a known attribute of a known object has confidence 1.0.
-     - A reference to an unknown attribute of a known object has confidence 1.0. These are mainly generated by imports, when the imported file is not in the analyzed set. (Does this need a third value, such as 0.5?)
-     - A reference to an attribute of an unknown object has confidence 0.0.
-   - A wildcard and its expansions have confidence 0.0.
-   - Effects of binding analysis? The system should not claim full confidence in a bound value, unless it fully understands both the binding syntax and the value. (Note that this is very restrictive. A function call or a list in the expression for the value will currently spoil the full analysis.)
-   - Confidence values may need updating in pass 2.
- - Make the analyzer understand `del name` (probably seen as `isinstance(node.ctx, ast.Del)` in `visit_Name()`, `visit_Attribute()`)
- - Prefix methods by class name in the graph; create a legend for annotations. See the discussion [here](https://github.com/johnyf/pyan/issues/4).
- - Improve the wildcard resolution mechanism, see discussion [here](https://github.com/johnyf/pyan/issues/5).
-   - Could record the namespace of the use site upon creating the wildcard, and check any possible resolutions against that (requiring that the resolved name is in scope at the use site)?
- - Add an option to visualize relations only between namespaces, useful for large projects.
-   - Scan the nodes and edges, basically generate a new graph and visualize that.
- - Publish test cases.
- - Get rid of `self.last_value`?
-   - Consider each specific kind of expression or statement being handled; get the relevant info directly (or by a more controlled kind of recursion) instead of `self.visit()`.
-   - At some point, may need a second visitor class that is just a catch-all that extracts names, which is then applied to only relevant branches of the AST.
-   - On the other hand, maybe `self.last_value` is the simplest implementation that extracts a value from an expression, and it only needs to be used in a controlled manner (as `analyze_binding()` currently does); i.e. reset before visiting, and reset immediately when done.
+- Determine confidence of detected edges (probability that the edge is correct). Start with a binary system, with only values 1.0 and 0.0.
+  - A fully resolved reference to a name, based on lexical scoping, has confidence 1.0.
+  - A reference to an unknown name has confidence 0.0.
+  - Attributes:
+    - A fully resolved reference to a known attribute of a known object has confidence 1.0.
+    - A reference to an unknown attribute of a known object has confidence 1.0. These are mainly generated by imports, when the imported file is not in the analyzed set. (Does this need a third value, such as 0.5?)
+    - A reference to an attribute of an unknown object has confidence 0.0.
+  - A wildcard and its expansions have confidence 0.0.
+  - Effects of binding analysis? The system should not claim full confidence in a bound value, unless it fully understands both the binding syntax and the value. (Note that this is very restrictive. A function call or a list in the expression for the value will currently spoil the full analysis.)
+  - Confidence values may need updating in pass 2.
+- Make the analyzer understand `del name` (probably seen as `isinstance(node.ctx, ast.Del)` in `visit_Name()`, `visit_Attribute()`)
+- Prefix methods by class name in the graph; create a legend for annotations. See the discussion [here](https://github.com/johnyf/pyan/issues/4).
+- Improve the wildcard resolution mechanism, see discussion [here](https://github.com/johnyf/pyan/issues/5).
+  - Could record the namespace of the use site upon creating the wildcard, and check any possible resolutions against that (requiring that the resolved name is in scope at the use site)?
+- Add an option to visualize relations only between namespaces, useful for large projects.
+  - Scan the nodes and edges, basically generate a new graph and visualize that.
+- Publish test cases.
+- Get rid of `self.last_value`?
+  - Consider each specific kind of expression or statement being handled; get the relevant info directly (or by a more controlled kind of recursion) instead of `self.visit()`.
+  - At some point, may need a second visitor class that is just a catch-all that extracts names, which is then applied to only relevant branches of the AST.
+  - On the other hand, maybe `self.last_value` is the simplest implementation that extracts a value from an expression, and it only needs to be used in a controlled manner (as `analyze_binding()` currently does); i.e. reset before visiting, and reset immediately when done.
 
 The analyzer **does not currently support**:
 
- - Tuples/lists as first-class values (currently ignores any assignment of a tuple/list to a single name).
-   - Support empty lists, too (for resolving method calls to `.append()` and similar).
- - Starred assignment `a,*b,c = d,e,f,g,h`
- - Slicing and indexing in assignment (`ast.Subscript`)
- - Additional unpacking generalizations ([PEP 448](https://www.python.org/dev/peps/pep-0448/), Python 3.5+).
-   - Any **uses** on the RHS *at the binding site* in all of the above are already detected by the name and attribute analyzers, but the binding information from assignments of these forms will not be recorded (at least not correctly).
- - Enums; need to mark the use of any of their attributes as use of the Enum. Need to detect `Enum` in `bases` during analysis of ClassDef; then tag the class as an enum and handle differently.
- - Resolving results of function calls, except for a very limited special case for `super()`.
-   - Any binding of a name to a result of a function (or method) call - provided that the binding itself is understood by Pyan - will instead show in the output as binding the name to that function (or method). (This may generate some unintuitive uses edges in the graph.)
- - Distinguishing between different Lambdas in the same namespace (to report uses of a particular `lambda` that has been stored in `self.something`).
- - Type hints ([PEP 484](https://www.python.org/dev/peps/pep-0484/), Python 3.5+).
- - Type inference for function arguments
-   - Either of these two could be used to bind function argument names to the appropriate object types, avoiding the need for wildcard references (especially for attribute accesses on objects passed in as function arguments).
-   - Type inference could run as pass 3, using additional information from the state of the graph after pass 2 to connect call sites to function definitions. Alternatively, no additional pass; store the AST nodes in the earlier pass. Type inference would allow resolving some wildcards by finding the method of the actual object instance passed in.
-   - Must understand, at the call site, whether the first positional argument in the function def is handled implicitly or not. This is found by looking at the flavor of the Node representing the call target.
- - Async definitions are detected, but passed through to the corresponding non-async analyzers; could be annotated.
- - Cython; could strip or comment out Cython-specific code as a preprocess step, then treat as Python (will need to be careful to get line numbers right).
+- Tuples/lists as first-class values (currently ignores any assignment of a tuple/list to a single name).
+  - Support empty lists, too (for resolving method calls to `.append()` and similar).
+- Starred assignment `a,*b,c = d,e,f,g,h`
+- Slicing and indexing in assignment (`ast.Subscript`)
+- Additional unpacking generalizations ([PEP 448](https://www.python.org/dev/peps/pep-0448/), Python 3.5+).
+  - Any **uses** on the RHS _at the binding site_ in all of the above are already detected by the name and attribute analyzers, but the binding information from assignments of these forms will not be recorded (at least not correctly).
+- Enums; need to mark the use of any of their attributes as use of the Enum. Need to detect `Enum` in `bases` during analysis of ClassDef; then tag the class as an enum and handle differently.
+- Resolving results of function calls, except for a very limited special case for `super()`.
+  - Any binding of a name to a result of a function (or method) call - provided that the binding itself is understood by Pyan - will instead show in the output as binding the name to that function (or method). (This may generate some unintuitive uses edges in the graph.)
+- Distinguishing between different Lambdas in the same namespace (to report uses of a particular `lambda` that has been stored in `self.something`).
+- Type hints ([PEP 484](https://www.python.org/dev/peps/pep-0484/), Python 3.5+).
+- Type inference for function arguments
+  - Either of these two could be used to bind function argument names to the appropriate object types, avoiding the need for wildcard references (especially for attribute accesses on objects passed in as function arguments).
+  - Type inference could run as pass 3, using additional information from the state of the graph after pass 2 to connect call sites to function definitions. Alternatively, no additional pass; store the AST nodes in the earlier pass. Type inference would allow resolving some wildcards by finding the method of the actual object instance passed in.
+  - Must understand, at the call site, whether the first positional argument in the function def is handled implicitly or not. This is found by looking at the flavor of the Node representing the call target.
+- Async definitions are detected, but passed through to the corresponding non-async analyzers; could be annotated.
+- Cython; could strip or comment out Cython-specific code as a preprocess step, then treat as Python (will need to be careful to get line numbers right).
 
 # How it works
 
@@ -182,7 +221,7 @@ class MyClass:
 
     def dostuff(self)
         self.f()
-```
+````
 
 By tracking the name `self.f`, the analyzer will see that `MyClass.dostuff()` uses `some_func()`.
 

--- a/pyan/sphinx.py
+++ b/pyan/sphinx.py
@@ -1,0 +1,169 @@
+"""
+Simple sphinx extension that allows including callgraphs in documentation.
+
+Example usage:
+
+```
+.. callgraph:: <function_name>
+
+
+Options are
+
+- **:no-groups:** (boolean flag): do not group
+- **:no-defines:** (boolean flag): if to not draw edges that show which
+  functions, methods and classes are defined by a class or module
+- **:no-uses:** (boolean flag): if to not draw edges that show how a function
+  uses other functions
+- **:no-colors:** (boolean flag): if to not color in callgraph (default is
+  coloring)
+- **:nested-grops:** (boolean flag): if to group by modules and submodules
+- **:annotated:** (boolean flag): annotate callgraph with file names
+- **:direction:** (string): "horizontal" or "vertical" callgraph
+- **:toctree:** (string): path to toctree (as used with autosummary) to link
+  elements of callgraph to documentation (makes all nodes clickable)
+- **:zoomable:** (boolean flag): enables users to zoom and pan callgraph
+```
+"""
+import re
+from typing import Any
+
+from docutils.parsers.rst import directives
+from pyan import create_callgraph
+from sphinx.ext.graphviz import align_spec, figure_wrapper, graphviz
+from sphinx.util.docutils import SphinxDirective
+
+
+def direction_spec(argument: Any) -> str:
+    return directives.choice(argument, ("vertical", "horizontal"))
+
+
+class CallgraphDirective(SphinxDirective):
+
+    # this enables content in the directive
+    has_content = True
+
+    option_spec = {
+        # graphviz
+        "alt": directives.unchanged,
+        "align": align_spec,
+        "caption": directives.unchanged,
+        "name": directives.unchanged,
+        "class": directives.class_option,
+        # pyan
+        "no-groups": directives.unchanged,
+        "no-defines": directives.unchanged,
+        "no-uses": directives.unchanged,
+        "no-colors": directives.unchanged,
+        "nested-groups": directives.unchanged,
+        "annotated": directives.unchanged,
+        "direction": direction_spec,
+        "toctree": directives.unchanged,
+        "zoomable": directives.unchanged,
+    }
+
+    def run(self):
+        func_name = self.content[0]
+        base_name = func_name.split(".")[0]
+        if len(func_name.split(".")) == 1:
+            func_name = None
+        base_path = __import__(base_name).__path__[0]
+
+        direction = "vertical"
+        if "direction" in self.options:
+            direction = self.options["direction"]
+        dotcode = create_callgraph(
+            filenames=f"{base_path}/**/*.py",
+            function=func_name,
+            namespace=base_name,
+            format="dot",
+            grouped="no-groups" not in self.options,
+            draw_uses="no-uses" not in self.options,
+            draw_defines="no-defines" not in self.options,
+            nested_groups="nested-groups" in self.options,
+            colored="no-colors" not in self.options,
+            annotated="annotated" in self.options,
+            rankdir={"horizontal": "LR", "vertical": "TB"}[direction],
+        )
+        node = graphviz()
+
+        # insert link targets into groups: first insert link, then reformat link
+        if "toctree" in self.options:
+            path = self.options["toctree"].strip("/")
+            # create raw link
+            dotcode = re.sub(
+                r'([\w\d]+)(\s.+), (style="filled")',
+                r'\1\2, href="../' + path + r'/\1.html", target="_blank", \3',
+                dotcode,
+            )
+
+            def create_link(dot_name):
+                raw_link = re.sub(r"__(\w)", r".\1", dot_name)
+                # determine if name this is a class by checking if its first letter is capital
+                # (heuristic but should work almost always)
+                splits = raw_link.rsplit(".", 2)
+                if len(splits) > 1 and splits[-2][0].capitalize() == splits[-2][0]:
+                    # is class
+                    link = ".".join(splits[:-1]) + ".html#" + raw_link + '"'
+                else:
+                    link = raw_link + '.html"'
+                return link
+
+            dotcode = re.sub(
+                r'(href="../' + path + r'/)(\w+)(\.html")',
+                lambda m: m.groups()[0] + create_link(m.groups()[1]),
+                dotcode,
+            )
+
+        node["code"] = dotcode
+        node["options"] = {"docname": self.env.docname}
+        if "graphviz_dot" in self.options:
+            node["options"]["graphviz_dot"] = self.options["graphviz_dot"]
+        if "layout" in self.options:
+            node["options"]["graphviz_dot"] = self.options["layout"]
+        if "alt" in self.options:
+            node["alt"] = self.options["alt"]
+        if "align" in self.options:
+            node["align"] = self.options["align"]
+
+        if "class" in self.options:
+            classes = self.options["class"]
+        else:
+            classes = []
+        if "zoomable" in self.options:
+            if len(classes) == 0:
+                classes = ["zoomable-callgraph"]
+            else:
+                classes.append("zoomable-callgraph")
+        if len(classes) > 0:
+            node["classes"] = classes
+
+        if "caption" not in self.options:
+            self.add_name(node)
+            return [node]
+        else:
+            figure = figure_wrapper(self, node, self.options["caption"])
+            self.add_name(figure)
+            return [figure]
+
+
+def setup(app):
+
+    app.add_directive("callgraph", CallgraphDirective)
+    app.add_js_file("https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js")
+
+    # script to find zoomable svgs
+    script = """
+    window.addEventListener('load', () => {
+        Array.from(document.getElementsByClassName('zoomable-callgraph')).forEach(function(element) {
+            svgPanZoom(element);
+        });
+    })
+    """
+
+    app.add_js_file(None, body=script)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
Adds `.. callgraph::` directive to insert automatically clickable and zoomable callgraphs to sphinx documentation.