### PR TITLE
Using recursive=True for glob

### DIFF
--- a/modvis.py
+++ b/modvis.py
@@ -11,7 +11,9 @@ from optparse import OptionParser  # TODO: migrate to argparse
 import pyan.node
 import pyan.visgraph
 import pyan.writers
+
 # from pyan.anutils import get_module_name
+
 
 def filename_to_module_name(fullpath):  # we need to see __init__, hence we don't use anutils.get_module_name.
     """'some/path/module.py' -> 'some.path.module'"""
@@ -19,16 +21,18 @@ def filename_to_module_name(fullpath):  # we need to see __init__, hence we don'
         raise ValueError("Expected a .py filename, got '{}'".format(fullpath))
     rel = ".{}".format(os.path.sep)  # ./
     if fullpath.startswith(rel):
-        fullpath = fullpath[len(rel):]
+        fullpath = fullpath[len(rel) :]
     fullpath = fullpath[:-3]  # remove .py
-    return fullpath.replace(os.path.sep, '.')
+    return fullpath.replace(os.path.sep, ".")
+
 
 def split_module_name(m):
     """'fully.qualified.name' -> ('fully.qualified', 'name')"""
-    k = m.rfind('.')
+    k = m.rfind(".")
     if k == -1:
         return ("", m)
-    return (m[:k], m[(k + 1):])
+    return (m[:k], m[(k + 1) :])
+
 
 # blacklist = (".git", "build", "dist", "test")
 # def find_py_files(basedir):
@@ -42,6 +46,7 @@ def split_module_name(m):
 #                 fullpath = os.path.join(root, filename)
 #                 py_files.append(fullpath)
 #     return py_files
+
 
 def resolve(current_module, target_module, level):
     """Return fully qualified name of the target_module in an import.
@@ -72,11 +77,12 @@ def resolve(current_module, target_module, level):
             base = ""
             break
         base = base[:k]
-    return '.'.join((base, target_module))
+    return ".".join((base, target_module))
+
 
 class ImportVisitor(ast.NodeVisitor):
     def __init__(self, filenames, logger):
-        self.modules = {}    # modname: {dep0, dep1, ...}
+        self.modules = {}  # modname: {dep0, dep1, ...}
         self.fullpaths = {}  # modname: fullpath
         self.logger = logger
         self.analyze(filenames)
@@ -115,14 +121,20 @@ class ImportVisitor(ast.NodeVisitor):
                 self.logger.debug("    added possible implicit use of '{}'".format(possible_init))
 
     def visit_Import(self, node):
-        self.logger.debug("{}:{}: Import {}".format(self.current_module, node.lineno, [alias.name for alias in node.names]))
+        self.logger.debug(
+            "{}:{}: Import {}".format(self.current_module, node.lineno, [alias.name for alias in node.names])
+        )
         for alias in node.names:
             self.add_dependency(alias.name)  # alias.asname not relevant for our purposes
 
     def visit_ImportFrom(self, node):
         # from foo import some_symbol
         if node.module:
-            self.logger.debug("{}:{}: ImportFrom '{}', relative import level {}".format(self.current_module, node.lineno, node.module, node.level))
+            self.logger.debug(
+                "{}:{}: ImportFrom '{}', relative import level {}".format(
+                    self.current_module, node.lineno, node.module, node.level
+                )
+            )
             absname = resolve(self.current_module, node.module, node.level)
             if node.level > 0:
                 self.logger.debug("    resolved relative import to '{}'".format(absname))
@@ -131,7 +143,11 @@ class ImportVisitor(ast.NodeVisitor):
         # from . import foo  -->  module = None; now the **names** refer to modules
         else:
             for alias in node.names:
-                self.logger.debug("{}:{}: ImportFrom '{}', target module '{}', relative import level {}".format(self.current_module, node.lineno, '.' * node.level, alias.name, node.level))
+                self.logger.debug(
+                    "{}:{}: ImportFrom '{}', target module '{}', relative import level {}".format(
+                        self.current_module, node.lineno, "." * node.level, alias.name, node.level
+                    )
+                )
                 absname = resolve(self.current_module, alias.name, node.level)
                 if node.level > 0:
                     self.logger.debug("    resolved relative import to '{}'".format(absname))
@@ -147,6 +163,7 @@ class ImportVisitor(ast.NodeVisitor):
         the cyclic part (where the first and last elements are the same).
         """
         cycles = []
+
         def walk(m, seen=None, trace=None):
             trace = (trace or []) + [m]
             seen = seen or set()
@@ -158,6 +175,7 @@ class ImportVisitor(ast.NodeVisitor):
             for d in sorted(deps):
                 if d in self.modules:
                     walk(d, seen, trace)
+
         for root in sorted(self.modules):
             walk(root)
 
@@ -171,7 +189,7 @@ class ImportVisitor(ast.NodeVisitor):
 
     def prepare_graph(self):  # same format as in pyan.analyzer
         """Postprocessing. Prepare data for pyan.visgraph for graph file generation."""
-        self.nodes = {}   # Node name: list of Node objects (in possibly different namespaces)
+        self.nodes = {}  # Node name: list of Node objects (in possibly different namespaces)
         self.uses_edges = {}
         # we have no defines_edges, which doesn't matter as long as we don't enable that option in visgraph.
 
@@ -188,11 +206,7 @@ class ImportVisitor(ast.NodeVisitor):
             # TODO: it could be useful to decide the hue by the top-level directory name
             # TODO: (after the './' if any), and lightness by the depth in each tree.
             # TODO: This would be most similar to how Pyan does it for functions/classes.
-            n = pyan.node.Node(namespace=ns,
-                               name=mod,
-                               ast_node=None,
-                               filename=package,
-                               flavor=pyan.node.Flavor.MODULE)
+            n = pyan.node.Node(namespace=ns, name=mod, ast_node=None, filename=package, flavor=pyan.node.Flavor.MODULE)
             n.defined = True
             # Pyan's analyzer.py allows several nodes to share the same short name,
             # which is used as the key to self.nodes; but we use the fully qualified
@@ -218,68 +232,89 @@ class ImportVisitor(ast.NodeVisitor):
             for d in deps:
                 assert d.get_name() in self.nodes
 
+
 def main():
     usage = """usage: %prog FILENAME... [--dot|--tgf|--yed]"""
-    desc = ('Analyse one or more Python source files and generate an'
-            'approximate module dependency graph.')
+    desc = "Analyse one or more Python source files and generate an" "approximate module dependency graph."
     parser = OptionParser(usage=usage, description=desc)
-    parser.add_option("--dot",
-                      action="store_true", default=False,
-                      help="output in GraphViz dot format")
-    parser.add_option("--tgf",
-                      action="store_true", default=False,
-                      help="output in Trivial Graph Format")
-    parser.add_option("--yed",
-                      action="store_true", default=False,
-                      help="output in yEd GraphML Format")
-    parser.add_option("-f", "--file", dest="filename",
-                      help="write graph to FILE", metavar="FILE", default=None)
-    parser.add_option("-l", "--log", dest="logname",
-                      help="write log to LOG", metavar="LOG")
-    parser.add_option("-v", "--verbose",
-                      action="store_true", default=False, dest="verbose",
-                      help="verbose output")
-    parser.add_option("-V", "--very-verbose",
-                      action="store_true", default=False, dest="very_verbose",
-                      help="even more verbose output (mainly for debug)")
-    parser.add_option("-c", "--colored",
-                      action="store_true", default=False, dest="colored",
-                      help="color nodes according to namespace [dot only]")
-    parser.add_option("-g", "--grouped",
-                      action="store_true", default=False, dest="grouped",
-                      help="group nodes (create subgraphs) according to namespace [dot only]")
-    parser.add_option("-e", "--nested-groups",
-                      action="store_true", default=False, dest="nested_groups",
-                      help="create nested groups (subgraphs) for nested namespaces (implies -g) [dot only]")
-    parser.add_option("-C", "--cycles",
-                      action="store_true", default=False, dest="cycles",
-                      help="detect import cycles and print report to stdout")
-    parser.add_option("--dot-rankdir", default="TB", dest="rankdir",
-                      help=(
-                          "specifies the dot graph 'rankdir' property for "
-                          "controlling the direction of the graph. "
-                          "Allowed values: ['TB', 'LR', 'BT', 'RL']. "
-                          "[dot only]"))
-    parser.add_option("-a", "--annotated",
-                      action="store_true", default=False, dest="annotated",
-                      help="annotate with module location")
+    parser.add_option("--dot", action="store_true", default=False, help="output in GraphViz dot format")
+    parser.add_option("--tgf", action="store_true", default=False, help="output in Trivial Graph Format")
+    parser.add_option("--yed", action="store_true", default=False, help="output in yEd GraphML Format")
+    parser.add_option("-f", "--file", dest="filename", help="write graph to FILE", metavar="FILE", default=None)
+    parser.add_option("-l", "--log", dest="logname", help="write log to LOG", metavar="LOG")
+    parser.add_option("-v", "--verbose", action="store_true", default=False, dest="verbose", help="verbose output")
+    parser.add_option(
+        "-V",
+        "--very-verbose",
+        action="store_true",
+        default=False,
+        dest="very_verbose",
+        help="even more verbose output (mainly for debug)",
+    )
+    parser.add_option(
+        "-c",
+        "--colored",
+        action="store_true",
+        default=False,
+        dest="colored",
+        help="color nodes according to namespace [dot only]",
+    )
+    parser.add_option(
+        "-g",
+        "--grouped",
+        action="store_true",
+        default=False,
+        dest="grouped",
+        help="group nodes (create subgraphs) according to namespace [dot only]",
+    )
+    parser.add_option(
+        "-e",
+        "--nested-groups",
+        action="store_true",
+        default=False,
+        dest="nested_groups",
+        help="create nested groups (subgraphs) for nested namespaces (implies -g) [dot only]",
+    )
+    parser.add_option(
+        "-C",
+        "--cycles",
+        action="store_true",
+        default=False,
+        dest="cycles",
+        help="detect import cycles and print report to stdout",
+    )
+    parser.add_option(
+        "--dot-rankdir",
+        default="TB",
+        dest="rankdir",
+        help=(
+            "specifies the dot graph 'rankdir' property for "
+            "controlling the direction of the graph. "
+            "Allowed values: ['TB', 'LR', 'BT', 'RL']. "
+            "[dot only]"
+        ),
+    )
+    parser.add_option(
+        "-a", "--annotated", action="store_true", default=False, dest="annotated", help="annotate with module location"
+    )
 
     options, args = parser.parse_args()
-    filenames = [fn2 for fn in args for fn2 in glob(fn)]
+    filenames = [fn2 for fn in args for fn2 in glob(fn, recursive=True)]
     if len(args) == 0:
-        parser.error('Need one or more filenames to process')
+        parser.error("Need one or more filenames to process")
 
     if options.nested_groups:
         options.grouped = True
 
     graph_options = {
-            'draw_defines': False,  # we have no defines edges
-            'draw_uses': True,
-            'colored': options.colored,
-            'grouped_alt': False,
-            'grouped': options.grouped,
-            'nested_groups': options.nested_groups,
-            'annotated': options.annotated}
+        "draw_defines": False,  # we have no defines edges
+        "draw_uses": True,
+        "colored": options.colored,
+        "grouped_alt": False,
+        "grouped": options.grouped,
+        "nested_groups": options.nested_groups,
+        "annotated": options.annotated,
+    }
 
     # TODO: use an int argument for verbosity
     logger = logging.getLogger(__name__)
@@ -333,10 +368,13 @@ def main():
             for prefix, cycle in cycles:
                 unique_cycles.add(tuple(cycle))
             print("Detected the following import cycles (n_results={}).".format(len(unique_cycles)))
+
             def stats():
                 lengths = [len(x) - 1 for x in unique_cycles]  # number of modules in the cycle
+
                 def mean(lst):
                     return sum(lst) / len(lst)
+
                 def median(lst):
                     tmp = list(sorted(lst))
                     n = len(lst)
@@ -344,8 +382,12 @@ def main():
                         return tmp[n // 2]  # e.g. tmp[5] if n = 11
                     else:
                         return (tmp[n // 2 - 1] + tmp[n // 2]) / 2  # e.g. avg of tmp[4] and tmp[5] if n = 10
+
                 return min(lengths), mean(lengths), median(lengths), max(lengths)
-            print("Number of modules in a cycle: min = {}, average = {:0.2g}, median = {:0.2g}, max = {}".format(*stats()))
+
+            print(
+                "Number of modules in a cycle: min = {}, average = {:0.2g}, median = {:0.2g}, max = {}".format(*stats())
+            )
             for c in sorted(unique_cycles):
                 print("    {}".format(c))
 
@@ -364,18 +406,16 @@ def main():
         graph = pyan.visgraph.VisualGraph.from_visitor(v, options=graph_options, logger=logger)
 
     if options.dot:
-        writer = pyan.writers.DotWriter(graph,
-                                        options=['rankdir=' + options.rankdir],
-                                        output=options.filename,
-                                        logger=logger)
+        writer = pyan.writers.DotWriter(
+            graph, options=["rankdir=" + options.rankdir], output=options.filename, logger=logger
+        )
     if options.tgf:
-        writer = pyan.writers.TgfWriter(
-                graph, output=options.filename, logger=logger)
+        writer = pyan.writers.TgfWriter(graph, output=options.filename, logger=logger)
     if options.yed:
-        writer = pyan.writers.YedWriter(
-                graph, output=options.filename, logger=logger)
+        writer = pyan.writers.YedWriter(graph, output=options.filename, logger=logger)
     if make_graph:
         writer.run()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/pyan/__init__.py
+++ b/pyan/__init__.py
@@ -27,6 +27,7 @@ def create_callgraph(
     grouped_alt: bool = False,
     annotated: bool = False,
     grouped: bool = True,
+    max_iter: int = 1000,
 ) -> str:
     """
     create callgraph based on static code analysis
@@ -49,6 +50,7 @@ def create_callgraph(
         grouped_alt: if to use alternative grouping
         annotated: if to annotate graph with filenames
         grouped: if to group by modules
+        max_iter: maximum number of iterations for filtering. Defaults to 1000.
 
     Returns:
         str: callgraph
@@ -77,7 +79,7 @@ def create_callgraph(
             node = v.get_node(function_namespace, function_name)
         else:
             node = None
-        v.filter(node=node, namespace=namespace)
+        v.filter(node=node, namespace=namespace, max_iter=max_iter)
     graph = VisualGraph.from_visitor(v, options=graph_options)
 
     stream = io.StringIO()

--- a/pyan/main.py
+++ b/pyan/main.py
@@ -17,159 +17,115 @@ from .analyzer import CallGraphVisitor
 from .visgraph import VisualGraph
 from .writers import TgfWriter, DotWriter, YedWriter, HTMLWriter, SVGWriter
 
+
 def main(cli_args=None):
     usage = """%(prog)s FILENAME... [--dot|--tgf|--yed|--svg|--html]"""
     desc = (
-        'Analyse one or more Python source files and generate an'
-        'approximate call graph of the modules, classes and functions'
-        ' within them.'
+        "Analyse one or more Python source files and generate an"
+        "approximate call graph of the modules, classes and functions"
+        " within them."
     )
 
     parser = ArgumentParser(usage=usage, description=desc)
 
-    parser.add_argument(
-        "--dot",
-        action="store_true",
-        default=False,
-        help="output in GraphViz dot format"
-    )
+    parser.add_argument("--dot", action="store_true", default=False, help="output in GraphViz dot format")
+
+    parser.add_argument("--tgf", action="store_true", default=False, help="output in Trivial Graph Format")
+
+    parser.add_argument("--svg", action="store_true", default=False, help="output in SVG Format")
+
+    parser.add_argument("--html", action="store_true", default=False, help="output in HTML Format")
+
+    parser.add_argument("--yed", action="store_true", default=False, help="output in yEd GraphML Format")
+
+    parser.add_argument("--file", dest="filename", help="write graph to FILE", metavar="FILE", default=None)
+
+    parser.add_argument("--namespace", dest="namespace", help="filter for NAMESPACE", metavar="NAMESPACE", default=None)
+
+    parser.add_argument("--function", dest="function", help="filter for FUNCTION", metavar="FUNCTION", default=None)
+
+    parser.add_argument("-l", "--log", dest="logname", help="write log to LOG", metavar="LOG")
+
+    parser.add_argument("-v", "--verbose", action="store_true", default=False, dest="verbose", help="verbose output")
 
     parser.add_argument(
-        "--tgf",
-        action="store_true",
-        default=False,
-        help="output in Trivial Graph Format"
-    )
-
-    parser.add_argument(
-        "--svg",
-        action="store_true",
-        default=False,
-        help="output in SVG Format"
-    )
-
-    parser.add_argument(
-        "--html",
-        action="store_true",
-        default=False,
-        help="output in HTML Format"
-    )
-
-    parser.add_argument(
-        "--yed",
-        action="store_true",
-        default=False,
-        help="output in yEd GraphML Format"
-    )
-
-    parser.add_argument(
-        "--file",
-        dest="filename",
-        help="write graph to FILE",
-        metavar="FILE",
-        default=None
-    )
-
-    parser.add_argument(
-        "--namespace",
-        dest="namespace",
-        help="filter for NAMESPACE",
-        metavar="NAMESPACE",
-        default=None
-    )
-
-    parser.add_argument(
-        "--function",
-        dest="function",
-        help="filter for FUNCTION",
-        metavar="FUNCTION",
-        default=None
-    )
-
-    parser.add_argument(
-        "-l", "--log",
-        dest="logname",
-        help="write log to LOG",
-        metavar="LOG"
-    )
-
-    parser.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        default=False,
-        dest="verbose",
-        help="verbose output"
-    )
-
-    parser.add_argument(
-        "-V", "--very-verbose",
+        "-V",
+        "--very-verbose",
         action="store_true",
         default=False,
         dest="very_verbose",
-        help="even more verbose output (mainly for debug)"
+        help="even more verbose output (mainly for debug)",
     )
 
     parser.add_argument(
-        "-d", "--defines",
+        "-d",
+        "--defines",
         action="store_true",
         dest="draw_defines",
-        help="add edges for 'defines' relationships [default]"
+        help="add edges for 'defines' relationships [default]",
     )
 
     parser.add_argument(
-        "-n", "--no-defines",
+        "-n",
+        "--no-defines",
         action="store_false",
         default=True,
         dest="draw_defines",
-        help="do not add edges for 'defines' relationships"
+        help="do not add edges for 'defines' relationships",
     )
 
     parser.add_argument(
-        "-u", "--uses",
+        "-u",
+        "--uses",
         action="store_true",
         default=True,
         dest="draw_uses",
-        help="add edges for 'uses' relationships [default]"
+        help="add edges for 'uses' relationships [default]",
     )
 
     parser.add_argument(
-        "-N", "--no-uses",
+        "-N",
+        "--no-uses",
         action="store_false",
         default=True,
         dest="draw_uses",
-        help="do not add edges for 'uses' relationships"
+        help="do not add edges for 'uses' relationships",
     )
 
     parser.add_argument(
-        "-c", "--colored",
+        "-c",
+        "--colored",
         action="store_true",
         default=False,
         dest="colored",
-        help="color nodes according to namespace [dot only]"
+        help="color nodes according to namespace [dot only]",
     )
 
     parser.add_argument(
-        "-G", "--grouped-alt",
+        "-G",
+        "--grouped-alt",
         action="store_true",
         default=False,
         dest="grouped_alt",
-        help="suggest grouping by adding invisible defines edges [only useful with --no-defines]"
+        help="suggest grouping by adding invisible defines edges [only useful with --no-defines]",
     )
 
     parser.add_argument(
-        "-g", "--grouped",
+        "-g",
+        "--grouped",
         action="store_true",
         default=False,
         dest="grouped",
-        help="group nodes (create subgraphs) according to namespace [dot only]"
+        help="group nodes (create subgraphs) according to namespace [dot only]",
     )
 
     parser.add_argument(
-        "-e", "--nested-groups",
+        "-e",
+        "--nested-groups",
         action="store_true",
         default=False,
         dest="nested_groups",
-        help="create nested groups (subgraphs) for nested namespaces (implies -g) [dot only]"
+        help="create nested groups (subgraphs) for nested namespaces (implies -g) [dot only]",
     )
 
     parser.add_argument(
@@ -181,37 +137,38 @@ def main(cli_args=None):
             "controlling the direction of the graph. "
             "Allowed values: ['TB', 'LR', 'BT', 'RL']. "
             "[dot only]"
-        )
+        ),
     )
 
     parser.add_argument(
-        "-a", "--annotated",
+        "-a",
+        "--annotated",
         action="store_true",
         default=False,
         dest="annotated",
-        help="annotate with module and source line number"
+        help="annotate with module and source line number",
     )
 
     known_args, unknown_args = parser.parse_known_args(cli_args)
 
-    filenames = [fn2 for fn in unknown_args for fn2 in glob(fn)]
+    filenames = [fn2 for fn in unknown_args for fn2 in glob(fn, recursive=True)]
 
     if len(unknown_args) == 0:
-        parser.error('Need one or more filenames to process')
+        parser.error("Need one or more filenames to process")
     elif len(filenames) == 0:
-        parser.error('No files found matching given glob: %s' % ' '.join(unknown_args))
+        parser.error("No files found matching given glob: %s" % " ".join(unknown_args))
 
     if known_args.nested_groups:
         known_args.grouped = True
 
     graph_options = {
-        'draw_defines': known_args.draw_defines,
-        'draw_uses': known_args.draw_uses,
-        'colored': known_args.colored,
-        'grouped_alt': known_args.grouped_alt,
-        'grouped': known_args.grouped,
-        'nested_groups': known_args.nested_groups,
-        'annotated': known_args.annotated
+        "draw_defines": known_args.draw_defines,
+        "draw_uses": known_args.draw_uses,
+        "colored": known_args.colored,
+        "grouped_alt": known_args.grouped_alt,
+        "grouped": known_args.grouped,
+        "nested_groups": known_args.nested_groups,
+        "annotated": known_args.annotated,
     }
 
     # TODO: use an int argument for verbosity
@@ -251,46 +208,23 @@ def main(cli_args=None):
     writer = None
 
     if known_args.dot:
-        writer = DotWriter(
-            graph,
-            options=['rankdir=' + known_args.rankdir],
-            output=known_args.filename,
-            logger=logger
-        )
+        writer = DotWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
 
     if known_args.html:
-        writer = HTMLWriter(
-            graph,
-            options=['rankdir=' + known_args.rankdir],
-            output=known_args.filename,
-            logger=logger
-        )
+        writer = HTMLWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
 
     if known_args.svg:
-        writer = SVGWriter(
-            graph,
-            options=['rankdir=' + known_args.rankdir],
-            output=known_args.filename,
-            logger=logger
-        )
+        writer = SVGWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
 
     if known_args.tgf:
-        writer = TgfWriter(
-            graph,
-            output=known_args.filename,
-            logger=logger
-        )
+        writer = TgfWriter(graph, output=known_args.filename, logger=logger)
 
     if known_args.yed:
-        writer = YedWriter(
-            graph,
-            output=known_args.filename,
-            logger=logger
-        )
+        writer = YedWriter(graph, output=known_args.filename, logger=logger)
 
     if writer:
         writer.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Users expect to employ `glob(resursive=True)`, e.g. when trying to parse an entire package for a callgraph. This makes it consistent across the package.