### PR TITLE
Fix wrong arguments for CallGraphVisitor

### DIFF
--- a/pyan/main.py
+++ b/pyan/main.py
@@ -203,7 +203,7 @@ def main(cli_args=None):
         handler = logging.FileHandler(known_args.logname)
         logger.addHandler(handler)
 
-    v = CallGraphVisitor(filenames, logger, root=root)
+    v = CallGraphVisitor(filenames, logger=logger, root=root)
 
     if known_args.function or known_args.namespace:
 


### PR DESCRIPTION
Fixes #64

The `logger` variable is passed into the `root` parameter for `CallGraphVisitor` in `main.py`