### PR TITLE
feature: new params for graphviz + solves #70

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,8 @@ htmlcov
 .idea/
 .history/
 .vscode/
+
+# our vis. of architecture
+architecture.dot
+architecture.html
+architecture.svg

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See `pyan3 --help`.
 
 Example:
 
-`pyan *.py --uses --no-defines --colored --grouped --annotated --dot >myuses.dot`
+`pyan3 *.py --uses --no-defines --colored --grouped --annotated --dot >myuses.dot`
 
 Then render using your favorite GraphViz filter, mainly `dot` or `fdp`:
 
@@ -56,11 +56,11 @@ Then render using your favorite GraphViz filter, mainly `dot` or `fdp`:
 
 Or use directly
 
-`pyan *.py --uses --no-defines --colored --grouped --annotated --svg >myuses.svg`
+`pyan3 *.py --uses --no-defines --colored --grouped --annotated --svg >myuses.svg`
 
 You can also export as an interactive HTML
 
-`pyan *.py --uses --no-defines --colored --grouped --annotated --html > myuses.html`
+`pyan3 *.py --uses --no-defines --colored --grouped --annotated --html > myuses.html`
 
 Alternatively, you can call `pyan` from a script
 

--- a/pyan/main.py
+++ b/pyan/main.py
@@ -142,6 +142,31 @@ def main(cli_args=None):
     )
 
     parser.add_argument(
+        "--dot-ranksep",
+        default="0.5",
+        dest="ranksep",
+        help=(
+            "specifies the dot graph 'ranksep' property for "
+            "controlling desired rank separation, in inches. "
+            "Allowed values: [0.02 .. 1000.0]. "
+            "[dot only]"
+        ),
+    )
+
+    parser.add_argument(
+        "--graphviz-layout",
+        default="dot",
+        dest="layout",
+        help=(
+            "specifies the graphviz 'layout' property for "
+            "the name of the layout algorithm to use. "
+            "Allowed values: ['dot', 'neato', 'fdp', 'sfdp', 'twopi', 'circo']. "
+            "Recommended values: ['dot', 'fdp']. "
+            "[graphviz only]"
+        ),
+    )
+
+    parser.add_argument(
         "-a",
         "--annotated",
         action="store_true",
@@ -159,7 +184,12 @@ def main(cli_args=None):
 
     known_args, unknown_args = parser.parse_known_args(cli_args)
 
-    filenames = [fn2 for fn in unknown_args for fn2 in glob(fn, recursive=True)]
+
+    filenames = []
+    for fn in unknown_args:
+        for fn2 in glob(fn, recursive=True):
+            abs_fn2 = os.path.abspath(fn2)
+            filenames.append(abs_fn2)
 
     # determine root
     if known_args.root is not None:
@@ -203,6 +233,11 @@ def main(cli_args=None):
         handler = logging.FileHandler(known_args.logname)
         logger.addHandler(handler)
 
+    logger.debug(f"[files] {unknown_args}")
+
+    if root:
+        root = os.path.abspath(root)
+
     v = CallGraphVisitor(filenames, logger=logger, root=root)
 
     if known_args.function or known_args.namespace:
@@ -222,13 +257,25 @@ def main(cli_args=None):
     writer = None
 
     if known_args.dot:
-        writer = DotWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
+        writer = DotWriter(graph, options=[
+            "rankdir=" + known_args.rankdir,
+            "ranksep=" + known_args.ranksep,
+            "layout=" + known_args.layout,
+        ], output=known_args.filename, logger=logger)
 
     if known_args.html:
-        writer = HTMLWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
+        writer = HTMLWriter(graph, options=[
+            "rankdir=" + known_args.rankdir,
+            "ranksep=" + known_args.ranksep,
+            "layout=" + known_args.layout,
+        ], output=known_args.filename, logger=logger)
 
     if known_args.svg:
-        writer = SVGWriter(graph, options=["rankdir=" + known_args.rankdir], output=known_args.filename, logger=logger)
+        writer = SVGWriter(graph, options=[
+            "rankdir=" + known_args.rankdir,
+            "ranksep=" + known_args.ranksep,
+            "layout=" + known_args.layout,
+        ], output=known_args.filename, logger=logger)
 
     if known_args.tgf:
         writer = TgfWriter(graph, output=known_args.filename, logger=logger)

--- a/visualize_pyan_architecture.sh
+++ b/visualize_pyan_architecture.sh
@@ -2,3 +2,8 @@
 echo -ne "Pyan architecture: generating architecture.{dot,svg}\n"
 python3 -m pyan pyan/*.py --no-defines --uses --colored --annotate --dot -V >architecture.dot 2>architecture.log
 dot -Tsvg architecture.dot >architecture.svg
+echo -ne "Pyan architecture: generating architecture.{html,graphviz=fdp}\n"
+python3 -m pyan pyan/*.py --no-defines --uses \
+	--grouped --nested-groups \
+	--graphviz-layout fdp \
+	--colored --html > architecture.html


### PR DESCRIPTION
Changes:
- solve abs path bug #70
- new params for graphviz (`--dot-ranksep 5` -> ranksep; `--graphviz-layout fdp` -> layout)
  when working with `--html` and someone wants more space or zoom capacity, ranksep is helpful

- tested layout param on various projects: `dot` (default); `fdp` (square graph); 
   but every layout that is documented in: https://graphviz.org/documentation/#layout-manual-pages works.

- updated `.gitignore` (files gen. after `visualize_pyan_architecture.sh`)

*Example (`--graphviz-layout fdp`):*
<img width="510" alt="Screen Shot 2021-06-09 at 15 27 40" src="https://user-images.githubusercontent.com/1976088/121364759-5bc63500-c938-11eb-9b3b-f52e6a43855f.png">
