### PR TITLE
Fixed anutils.get_module_name

### DIFF
--- a/pyan/anutils.py
+++ b/pyan/anutils.py
@@ -39,6 +39,8 @@ def get_module_name(filename, root: str = None):
             potential_root = os.path.dirname(directories[0][0])
             is_root = any([f == "__init__.py" for f in os.listdir(potential_root)])
             directories.insert(0, (potential_root, is_root))
+            if is_root:
+                break
 
         # keep directories where itself of parent is root
         while not directories[0][1]:


### PR DESCRIPTION
Before this commit, I would get the following error:

```
Traceback (most recent call last):
  File "/home/sam/.local/share/virtualenvs/.repos-OcsR-W1w/bin/pyan3", line 33, in <module>
    sys.exit(load_entry_point('pyan3', 'console_scripts', 'pyan3')())
  File "/home/sam/box/charmonium.cache/benchmark/.repos/pyan/pyan/main.py", line 206, in main
    v = CallGraphVisitor(filenames, logger=logger, root=root)
  File "/home/sam/box/charmonium.cache/benchmark/.repos/pyan/pyan/analyzer.py", line 60, in __init__
    mod_name = get_module_name(filename)
  File "/home/sam/box/charmonium.cache/benchmark/.repos/pyan/pyan/anutils.py", line 43, in get_module_name
    is_root = any([f == "__init__.py" for f in os.listdir(potential_root)])
FileNotFoundError: [Errno 2] No such file or directory: ''
```

because `directories[0][0]` was:

```
./pudl/src/pudl/cli.py None
./pudl/src/pudl
./pudl/src
./pudl
.
```

After this commit, the code works as expected, because the loop stops when it finds the root.