### PR TITLE
get_module_name infinite loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,10 @@ htmlcov
 .idea/
 .history/
 .vscode/
+# Eclipse
+/.settings
+.project
+.pydevproject
+
+
+/tmp/

--- a/pyan/anutils.py
+++ b/pyan/anutils.py
@@ -32,6 +32,9 @@ def get_module_name(filename, root: str = None):
         # otherwise it is the filename without extension
         module_path = filename.replace(".py", "")
 
+    # will enter infinite loop or exception in case of non-absolute path (starting with ".")
+    module_path = os.path.abspath(module_path)
+
     # find the module root - walk up the tree and check if it contains .py files - if yes. it is the new root
     directories = [(module_path, True)]
     if root is None:
@@ -47,6 +50,9 @@ def get_module_name(filename, root: str = None):
     else:  # root is already known - just walk up until it is matched
         while directories[0][0] != root:
             potential_root = os.path.dirname(directories[0][0])
+            if potential_root == directories[0][0]:
+                # root directory reached - stop iteration
+                break
             directories.insert(0, (potential_root, True))
 
     mod_name = ".".join([os.path.basename(f[0]) for f in directories])

--- a/tests/test_anutils.py
+++ b/tests/test_anutils.py
@@ -1,0 +1,28 @@
+from glob import glob
+import logging
+import os
+
+import pytest
+
+from pyan.anutils import get_module_name
+
+
+def test_get_module_name_filename_not_existing():
+    mod_name = get_module_name("just_filename.py")
+    assert mod_name == "just_filename"
+
+
+def test_get_module_name_absolute():
+    mod_name = get_module_name(__file__)
+    assert mod_name == "test_anutils"
+
+
+def test_get_module_name_absolute_not_existing():
+    with pytest.raises(FileNotFoundError) as e_info:
+        get_module_name("/not/existing/abs_path/mod.py")
+
+    mod_name = get_module_name("/not/existing/mod_dir/mod.py", "mod_dir")
+    assert mod_name == ".not.existing.mod_dir.mod"
+
+    mod_name = get_module_name("/not/existing/mod_dir/mod.py", "invalid_root")
+    assert mod_name == ".not.existing.mod_dir.mod"


### PR DESCRIPTION
When passing relative paths to pyan3 infinite loop happened. PR resolves the problem.