### PR TITLE
fix bugs related to get_module_name and resolve_imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ htmlcov
 .idea/
 .history/
 .vscode/
+*.swp

--- a/pyan/analyzer.py
+++ b/pyan/analyzer.py
@@ -219,7 +219,7 @@ class CallGraphVisitor(ast.NodeVisitor):
                             and from_node.flavor == Flavor.IMPORTEDITEM
                         ):
                             # use define edges as potential candidates
-                            for candidate_to_node in self.defines_edges[to_node]:  #
+                            for candidate_to_node in self.defines_edges.get(to_node, []): # [to_node]:  #
                                 if candidate_to_node.name == node.name:
                                     attribute_import_mapping[node] = candidate_to_node
                                     break

--- a/pyan/anutils.py
+++ b/pyan/anutils.py
@@ -30,7 +30,7 @@ def get_module_name(filename, root: str = None):
         module_path = os.path.dirname(filename)
     else:
         # otherwise it is the filename without extension
-        module_path = filename.replace(".py", "")
+        module_path = filename.rstrip(".py")
 
     # find the module root - walk up the tree and check if it contains .py files - if yes. it is the new root
     directories = [(module_path, True)]


### PR DESCRIPTION
## get_module_name

Will replace all `.py` in a path like `/path/to/wheel-0.37.1-py2.py3-none-any/wheel/**/*.py`, which will make files can't be found from a wrong path (`/path/to/wheel-0.37.1-py23-none-any/wheel/**/*`).

## resolve_imports

Will raise a `KeyError` sometimes.