### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install depdencies
+        run: pip install setuptools pytest pytest-cov && python setup.py install
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Offline call graph generator for Python 3
 
 [![Build Status](https://travis-ci.com/edumco/pyan.svg?branch=master)](https://travis-ci.com/edumco/pyan)
+[![CI](https://github.com/Technologicat/pyan/actions/workflows/ci.yml/badge.svg)](https://github.com/Technologicat/pyan/actions/workflows/ci.yml)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fedumco%2Fpyan.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fedumco%2Fpyan?ref=badge_shield)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7cba5ba5d3694a42a1252243e3634b5e)](https://www.codacy.com/manual/edumco/pyan?utm_source=github.com&utm_medium=referral&utm_content=edumco/pyan&utm_campaign=Badge_Grade)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyan3)


### PR DESCRIPTION
This switches to GitHub actions from Travis CI for CI.
Note that the badge in the README won't actually work until the PR is merged.
