### PR TITLE
NAMESPACE_OBJECT overlay for namespace-constructor bindings (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features
 
 - **Module-level name bindings now produce graph Nodes.** Every module-level assignment (e.g. `CONSTANT = 42`, `LOGGER = logging.getLogger(__name__)`, `store = _NS()`) creates a defined `Flavor.NAME` Node at the bound dotted path. `from mymod import x` now resolves to the actual binding instead of contracting to a wildcard, and the #127 attribute-fallback lands on the specific binding rather than climbing all the way to the enclosing module. Function-locals are unchanged — they stay as scope-only bindings to keep the graph readable. Edgeless NAME Nodes (module constants nobody imports) are suppressed from the rendered output by default; they remain in the analyzer's graph for cross-module resolution.
+- **Namespace-style modules now resolve attribute access to the kwarg's target.** When the rhs of a binding is `Call(func=...)` whose resolved import origin is in the built-in registry (`unpythonic.env.env`, top-level re-export `unpythonic.env`, `types.SimpleNamespace`, `argparse.Namespace`), the LHS is upgraded to `Flavor.NAMESPACE_OBJECT` and its scope is populated with the call's keyword arguments. External `config.thingy` resolves directly to whatever was passed as `thingy=`, bypassing the #127 module-level fallback. Recognised at all four binding sites: `config = env(...)`, `config: Env = env(...)`, walrus `(config := env(...))`, and `with env(...) as config:`. Staged form `config = env(); config.a = baa` is also covered (later attribute writes populate the namespace's scope through the existing `set_attribute` machinery). `setattr(config, name, value)` writes are recognised when *name* is a string literal, a name bound to a string literal in any scope reachable from the call site, or an imported name resolving to a string literal in another module. (#129)
+- **`--namespace-constructor FQN`** registers an extra namespace-constructor beyond the built-in registry (e.g. `--namespace-constructor mylib.MyNamespace`). Repeatable, or comma-separated. Threaded through to the `create_callgraph` API as `namespace_constructors=[...]`. Supplying the option emits a one-shot stderr nudge inviting the user to file an issue if their constructor is reasonably common, so the built-in registry can grow from observed real-world use. (#129)
 
 ### Bug fixes
 
@@ -13,7 +15,7 @@
 
 ### Internal
 
-- **Flavor rename:** `Flavor.NAMESPACE` (synthetic structural marker for module/class/function scope bookkeeping) is now `Flavor.SCOPE`. The previous name is being freed up for an upcoming `Flavor.NAMESPACE_OBJECT` representing a runtime namespace value (env, SimpleNamespace, …). The Node represents the scope; the `Scope` class implements one — same concept at two layers.
+- **Flavor rename:** `Flavor.NAMESPACE` (synthetic structural marker for module/class/function scope bookkeeping) is now `Flavor.SCOPE`. The new `Flavor.NAMESPACE_OBJECT` represents a runtime namespace value (an `env` instance, a `SimpleNamespace` instance) — a `NAME` with a populated scope listing its statically-visible attributes. The Node represents the scope; the `Scope` class implements one — same concept at two layers.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ pyan3 src/ --dot --function pkg.mod.func --direction down   # callees only (what
 pyan3 src/ --dot --function pkg.mod.func --direction up     # callers only (what calls this function?)
 ```
 
+### Namespace-style modules
+
+Some libraries expose a runtime-built namespace value as their public surface — typically `unpythonic.env.env`, `types.SimpleNamespace`, or `argparse.Namespace`. For these, pyan recognises the constructor call and treats its kwargs as attribute bindings, so that an external `config.thingy` access resolves to the kwarg's target. The built-in registry covers four FQNs: `unpythonic.env.env`, the top-level re-export `unpythonic.env`, `types.SimpleNamespace`, and `argparse.Namespace`. To extend it for a project-specific constructor:
+
+```bash
+pyan3 src/ --dot --namespace-constructor mylib.MyNamespace
+```
+
+Repeatable, or comma-separated (`--namespace-constructor a.b,c.d`). The option also recognises `setattr(config, "k", v)` writes against a registered namespace value.
+
+For ad-hoc shims like `class _NS: pass; store = _NS()` — i.e. instances of project-local classes used as namespaces — pyan can't follow the construction statically (the class is local, not a known constructor), but cross-module `store.attr` access still surfaces the coupling: the edge lands on the binding's Node (the `store = ...` itself) rather than degrading to a wildcard. Add the class to `--namespace-constructor` if you want full attribute resolution.
+
 ### Excluding files
 
 Use `-x` / `--exclude` to filter out files before analysis. Patterns without a path separator match against the basename; patterns with a separator match against the full path. The option can be repeated. **Quote the pattern** to prevent the shell from expanding glob characters.

--- a/TODO_DEFERRED.md
+++ b/TODO_DEFERRED.md
@@ -44,15 +44,21 @@ Global IMPORTEDITEM remapping can leak function-level imports to siblings. Parti
 
 ## Test suite organization
 
-Tests are spread across few modules (`test_features.py`, `test_regressions.py`, `test_modvis.py`, `test_writers.py`, `test_analyzer.py`, `test_sphinx.py`, `test_coverage.py`). Consider reorganizing by concern — e.g. separate CLI tests from unit tests, group by module under test.
+Two related concerns: (1) tests are spread across few modules (`test_features.py`, `test_regressions.py`, `test_modvis.py`, `test_writers.py`, `test_analyzer.py`, `test_sphinx.py`, `test_coverage.py`) — consider reorganizing by concern (separate CLI tests from unit tests, group by module under test). (2) `test_features.py` specifically is now over 1000 lines and covers many distinct features — splitting into coherent subfeature files (e.g. `test_features_decorators.py`, `test_features_inheritance.py`, `test_features_namespace_objects.py`) would help readability without changing what's tested.
 
 ## Analyzer module split
 
-`analyzer.py` is ~2200 lines. Consider splitting into submodules (e.g. visitors, postprocessing, scope handling) without changing the public API.
+`analyzer.py` is ~2700 lines. Consider splitting into submodules (e.g. visitors, postprocessing, scope handling, NAMESPACE_OBJECT recognition) without changing the public API. Possible cuts: the postprocessing pipeline (`resolve_imports`, `contract_nonexistents`, `expand_unknowns`, `cull_inherited`, `collapse_inner`) is largely standalone and could move to its own module; the recognizers added for #129 (`_maybe_register_namespace_object`, `_maybe_register_setattr_call`, friends) could go to a `recognizers` submodule.
 
 ## Type annotations for pyan's own code
 
 Add type annotations to pyan's modules. The analyzer is the largest target (~2200 lines). Would improve IDE support and catch bugs.
+
+## NAMESPACE_OBJECT in a same-named module renders confusingly
+
+When a NAMESPACE_OBJECT is bound at the top of a module that shares its name (e.g. `raven.visualizer.app_state` contains `app_state = env(...)`), visgraph emits both a standalone node for the module and a cluster (group box) labelled with the same dotted path containing the env Node — visually two "raven.visualizer.app_state" boxes side by side. The data model is correct (module Node has its own edges; cluster groups Nodes whose namespace equals the module path), but the rendering doesn't disambiguate the two roles. Consider either suppressing the standalone module Node when its namespace also has a cluster, or labelling the cluster differently (e.g. with a leading marker).
+
+Discovered while smoke-testing #129 against Raven Visualizer (2026-04-29).
 
 ## Audit typing: abstract parameter types, concrete return types
 

--- a/pyan/analyzer.py
+++ b/pyan/analyzer.py
@@ -3,12 +3,15 @@
 """The AST visitor."""
 
 import ast
+import builtins as _builtins_module
 from collections import defaultdict
+from collections.abc import Iterable
 from contextlib import contextmanager
 import logging
 import symtable
 
 from .anutils import (
+    NAMESPACE_CONSTRUCTORS,
     ExecuteInInnerScope,
     Scope,
     UnresolvedSuperCallError,
@@ -69,8 +72,26 @@ class CallGraphVisitor(ast.NodeVisitor):
     all files.  This way use information between objects in different files
     can be gathered."""
 
-    def __init__(self, filenames, root: str = None, logger=None):
-        self._init_common(logger)
+    def __init__(self, filenames, root: str = None, logger=None,
+                 namespace_constructors: Iterable[str] | None = None):
+        """Construct a CallGraphVisitor and analyze *filenames*.
+
+        Args:
+            filenames: list of ``.py`` file paths to analyze.
+            root: project root directory.  When ``None``, inferred from
+                *filenames* via :func:`infer_root`.
+            logger: optional ``logging.Logger`` instance.
+            namespace_constructors: extra fully-qualified constructor names
+                to recognize beyond the built-in
+                :data:`~pyan.anutils.NAMESPACE_CONSTRUCTORS`.  When the rhs
+                of a binding is ``Call(func=...)`` whose resolved import
+                origin matches one of these (built-in ∪ user), the LHS is
+                upgraded to ``Flavor.NAMESPACE_OBJECT`` and its scope is
+                populated with the call's keyword arguments (#129).  Each
+                entry should be the canonical dotted import path
+                (e.g. ``"my.lib.MyNamespace"``).
+        """
+        self._init_common(logger, namespace_constructors)
 
         # Infer root from filenames when not explicitly given.
         # This ensures namespace packages (directories without __init__.py)
@@ -89,7 +110,8 @@ class CallGraphVisitor(ast.NodeVisitor):
         self.process()
 
     @classmethod
-    def from_sources(cls, sources, logger=None):
+    def from_sources(cls, sources, logger=None,
+                     namespace_constructors: Iterable[str] | None = None):
         """Create a CallGraphVisitor from in-memory sources (no file I/O).
 
         Args:
@@ -104,12 +126,13 @@ class CallGraphVisitor(ast.NodeVisitor):
                 (e.g. ``"pkg.sub.__init__"``) so that relative imports
                 resolve correctly.
             logger: optional ``logging.Logger`` instance.
+            namespace_constructors: see ``CallGraphVisitor.__init__``.
 
         Returns:
             A fully analyzed ``CallGraphVisitor``.
         """
         self = cls.__new__(cls)
-        self._init_common(logger)
+        self._init_common(logger, namespace_constructors)
         self.root = ""
 
         # Normalize sources: unparse ASTs, store source text.
@@ -130,9 +153,28 @@ class CallGraphVisitor(ast.NodeVisitor):
         self.process()
         return self
 
-    def _init_common(self, logger):
-        """Shared initialization for both constructors."""
+    def _init_common(self, logger, namespace_constructors: Iterable[str] | None = None):
+        """Shared initialization for both constructors.
+
+        *namespace_constructors* — see ``CallGraphVisitor.__init__``.  The
+        merged set (built-in registry ∪ user-supplied) is stored on
+        ``self.namespace_constructors`` for the recognition path to read.
+        """
         self.logger = logger or logging.getLogger(__name__)
+
+        # Merged set of namespace-constructor FQNs (built-in + user-supplied).
+        # Read by `_maybe_register_namespace_object` to upgrade the LHS of a
+        # recognized binding from `Flavor.NAME` to `Flavor.NAMESPACE_OBJECT`.
+        self.namespace_constructors: set[str] = NAMESPACE_CONSTRUCTORS | set(namespace_constructors or ())
+
+        # Per-namespace map of names bound to string-literal constants.
+        # Populated by `_bind_target` whenever the rhs is a string `Constant`.
+        # Read by `_resolve_name_to_string_literal` for `setattr` recognition
+        # when the second argument is a `Name` that has to trace back to a
+        # literal. Cross-module lookups follow the same module_to_filename
+        # path that import resolution uses.
+        # Structure: {namespace: {name: literal_string}}
+        self.name_literals = {}
 
         # Stack of sets; while non-empty, ``add_uses_edge`` records each edge's
         # to_node into the top set. Used by visit_FunctionDef to capture uses
@@ -1536,6 +1578,13 @@ class CallGraphVisitor(ast.NodeVisitor):
         for kw in node.keywords:
             self.visit(kw.value)
 
+        # Recognize ``setattr(target, name, value)`` against a
+        # NAMESPACE_OBJECT target — symmetric counterpart to ``e.k = v``
+        # for the dynamic form.  No-op for any non-matching call.  See
+        # ``_maybe_register_setattr_call`` for the three name-resolution
+        # levels (literal / scope-local / cross-module).
+        self._maybe_register_setattr_call(node)
+
         # see if we can predict the result
         try:
             result_node = self.resolve_builtins(node)
@@ -1753,17 +1802,27 @@ class CallGraphVisitor(ast.NodeVisitor):
 
         return None, flavor
 
-    def _bind_target(self, target, value):
+    def _bind_target(self, target, value, rhs_ast=None):
         """Bind an AST target node to a resolved value (a graph Node or None).
 
         Dispatches on target type: Name and Attribute perform scalar binding,
         Tuple/List recurse (all sub-targets get the same value), Starred
         unwraps to its inner target, and ast.arg handles function parameter
         defaults.
+
+        *rhs_ast* — when known — is the AST node of the rhs expression,
+        passed through so recognizers that need to inspect the rhs (e.g.
+        the namespace-constructor and string-literal recognizers) can
+        avoid having to re-derive it.  ``None`` for cases where the rhs
+        isn't a single expression (e.g. cartesian fallback in
+        ``analyze_binding``).
         """
         if isinstance(target, ast.Name):
             self.set_value(target.id, value)
             self._maybe_define_name_node(target)
+            if rhs_ast is not None:
+                self._maybe_register_name_literal(target, rhs_ast)
+                self._maybe_register_namespace_object(target, rhs_ast)
         elif isinstance(target, ast.Attribute):
             try:
                 if self.set_attribute(target, value):
@@ -1826,6 +1885,270 @@ class CallGraphVisitor(ast.NodeVisitor):
             self.logger.info(f"Def from {from_node} to NAME {to_node}")
         self.associate_node(to_node, name_target, self.filename)
 
+    def _maybe_register_name_literal(self, name_target, rhs_ast):
+        """If a ``Name`` binding's rhs is a string ``Constant``, record the
+        bound value in ``self.name_literals[ns][name]``.
+
+        Used by the ``setattr`` recognizer to trace ``setattr(obj, k, v)``
+        when ``k`` is a ``Name`` bound to a string literal (level 2:
+        scope-local, level 3: cross-module via import resolution).
+
+        Only literal strings are tracked — runtime-computed strings are
+        beyond static analysis by design.
+        """
+        if not isinstance(rhs_ast, ast.Constant):
+            return
+        if not isinstance(rhs_ast.value, str):
+            return
+        if not self.scope_stack:
+            return
+        # Track at module/class scope only (mirrors `_maybe_define_name_node`):
+        # function-local literal bindings aren't externally addressable, and
+        # cross-module lookups require the binding to live in a module's namespace.
+        if self.scope_stack[-1].type not in ("module", "class"):
+            return
+        from_node = self.get_node_of_current_namespace()
+        ns = from_node.get_name()
+        self.name_literals.setdefault(ns, {})[name_target.id] = rhs_ast.value
+
+    def _maybe_register_namespace_object(self, name_target, rhs_ast):
+        """Pattern: ``LHS = constructor(**kwargs)`` where *constructor*'s
+        fully-qualified import origin is in ``self.namespace_constructors``.
+
+        Recognizes:
+
+        - ``config = env(thingy=baa)`` (canonical)
+        - ``config: Env = env(thingy=baa)`` (annotated)
+        - ``(config := env(thingy=baa))`` (walrus)
+        - ``with env(thingy=baa) as config:`` (context manager — same path
+          via `_visit_with` → `analyze_binding`)
+
+        On a hit, the LHS Node (already created as ``Flavor.NAME`` by
+        ``_maybe_define_name_node``) gets its flavor upgraded to
+        ``Flavor.NAMESPACE_OBJECT``, and a scope is created for it whose
+        ``defs`` dict is populated with the call's keyword arguments.
+        Subsequent attribute reads (``config.thingy``) and writes
+        (``config.flag = value``) then resolve through the existing
+        ``get_attribute`` / ``set_attribute`` machinery.
+
+        No-op when the rhs isn't a recognized constructor call, or when
+        the binding is in a function scope (where no NAME Node exists).
+        """
+        if not isinstance(rhs_ast, ast.Call):
+            return
+        # Cheap gates first — most assignments aren't to module/class scope,
+        # and FQN resolution is comparatively expensive (scope-chain lookup
+        # and/or attribute resolution).
+        if not self.scope_stack or self.scope_stack[-1].type not in ("module", "class"):
+            return
+        fqn = self._resolve_constructor_fqn(rhs_ast.func)
+        if fqn is None or fqn not in self.namespace_constructors:
+            return
+        from_node = self.get_node_of_current_namespace()
+        ns = from_node.get_name()
+        # Locate the LHS Node (already created by `_maybe_define_name_node`)
+        # and upgrade its flavor.  Direct assignment bypasses
+        # `Flavor.specificity`'s upgrade gate, which is intentional —
+        # we have additional information (the rhs is a known constructor)
+        # that the gate doesn't know about.
+        obj_node = self.get_node(ns, name_target.id, name_target)
+        obj_node.flavor = Flavor.NAMESPACE_OBJECT
+        obj_node.defined = True
+        if self.add_defines_edge(from_node, obj_node):
+            self.logger.info(f"Def from {from_node} to NAMESPACE_OBJECT {obj_node}")
+        # Repoint the scope binding from the constructor (e.g. the env
+        # IMPORTEDITEM) to the new NAMESPACE_OBJECT Node, so that later
+        # ``config.attr`` lookups walk into ``mymod.config``'s scope rather
+        # than into the constructor's namespace.  Plain NAME Nodes don't do
+        # this — the binding is kept at the rhs value so e.g. ``pd =
+        # pandas; pd.DataFrame`` still resolves into pandas' namespace.
+        # NAMESPACE_OBJECT is the case where attribute resolution should
+        # stay on the LHS itself.
+        self.set_value(name_target.id, obj_node)
+        # Ensure the scope exists at construction time, even when no
+        # kwargs were passed.  Otherwise the staged form ``config = env();
+        # config.a = baa`` breaks: the later attribute write goes through
+        # ``set_attribute``, which writes into an *existing* scope but
+        # doesn't create one (writes to non-NAMESPACE_OBJECT obj.attr
+        # paths shouldn't materialize scopes either).
+        obj_ns = obj_node.get_name()
+        if obj_ns not in self.scopes:
+            self.scopes[obj_ns] = Scope.from_names(obj_ns, [])
+        for kw in rhs_ast.keywords:
+            if kw.arg is None:  # **kwargs splat — not statically visible
+                continue
+            self._register_namespace_object_attr(obj_node, kw.arg, self.visit(kw.value))
+
+    def _register_namespace_object_attr(self, obj_node, attr_name, attr_value):
+        """Write ``attr_name → attr_value`` into *obj_node*'s scope.
+
+        Used by both the constructor recognizer (for ``env(k=v)`` kwargs)
+        and the ``setattr`` recognizer (for literal-named
+        ``setattr(obj, "k", v)`` writes).  Idempotently creates the scope
+        first — needed for the staged form ``config = env(); config.a = v``,
+        where no kwargs at the construction site means no scope yet exists.
+
+        Plain ``obj.attr = v`` writes go through ``set_attribute`` instead;
+        that path skips when the scope is missing rather than creating it,
+        because writes to attribute paths on non-NAMESPACE_OBJECT objects
+        shouldn't materialize scopes for arbitrary objects.
+        """
+        obj_ns = obj_node.get_name()
+        if obj_ns not in self.scopes:
+            self.scopes[obj_ns] = Scope.from_names(obj_ns, [])
+        self.scopes[obj_ns].defs[attr_name] = attr_value
+        self.logger.info(f"Registered {attr_name} -> {attr_value} in NAMESPACE_OBJECT {obj_node}")
+
+    def _resolve_constructor_fqn(self, func_ast):
+        """Resolve a ``Call.func`` AST to its fully-qualified import origin
+        as a dotted string, or ``None`` if not statically determinable.
+
+        Three cases:
+
+        - ``Name('env')`` where ``env`` is a user-bound name — looks up via
+          ``get_value``, returns ``namespace + "." + name`` of the
+          resolved Node.  Handles ``from unpythonic.env import env``
+          (FQN ``"unpythonic.env.env"``) and ``from unpythonic import env``
+          (FQN ``"unpythonic.env"``).
+        - ``Name('setattr')`` where the name isn't user-bound but matches a
+          Python builtin — returns ``"builtins.<name>"``.  Lets the
+          ``setattr`` recognizer match the unaliased call.  Aliased
+          builtins (``from builtins import setattr as sa``) take the first
+          path automatically, since the import binds the name.
+        - ``Attribute(Name('types'), 'SimpleNamespace')`` — first tries to
+          look up the resolved attr Node (analyzed-source case).  Failing
+          that, reconstructs the FQN from the dotted AST path
+          (unanalyzed-module case: ``import types; types.SimpleNamespace``).
+        """
+        if isinstance(func_ast, ast.Name):
+            node = self.get_value(func_ast.id)
+            if isinstance(node, Node) and node.namespace is not None:
+                return self._fqn_of_node(node)
+            # Builtin fallback — only fires when the name isn't user-bound.
+            if hasattr(_builtins_module, func_ast.id):
+                return f"builtins.{func_ast.id}"
+            return None
+        if isinstance(func_ast, ast.Attribute):
+            try:
+                obj_node, attr_name = self.resolve_attribute(func_ast)
+            except UnresolvedSuperCallError:
+                return None
+            if not isinstance(obj_node, Node) or obj_node.namespace is None:
+                return None
+            ns = obj_node.get_name()
+            if ns in self.scopes and attr_name in self.scopes[ns].defs:
+                resolved = self.scopes[ns].defs[attr_name]
+                if isinstance(resolved, Node):
+                    return self._fqn_of_node(resolved)
+            # Unanalyzed-module case: reconstruct from the dotted path.
+            return f"{ns}.{attr_name}"
+        return None
+
+    @staticmethod
+    def _fqn_of_node(node):
+        if not node.namespace:
+            return node.name
+        return f"{node.namespace}.{node.name}"
+
+    def _resolve_setattr_name(self, name_arg_ast):
+        """Resolve the second argument of ``setattr(obj, name, value)`` to a
+        string, following three concentric levels of static knowability.
+
+        - **Level 1 — literal string.** ``ast.Constant(value=str)``.  Use
+          the value directly.
+        - **Level 2 — name-bound literal.** ``ast.Name(id=k)`` where ``k``
+          is bound to a string literal in a scope reachable from here
+          (current scope chain).
+        - **Level 3 — cross-module name-bound literal.** ``ast.Name(id=k)``
+          where ``k`` resolves through an import to a string literal in
+          another analyzed module.
+
+        Returns the resolved string, or ``None`` if not statically
+        knowable (loop variables, function-returned strings, dynamic
+        construction — out of scope by design for a static analyzer).
+        """
+        if isinstance(name_arg_ast, ast.Constant) and isinstance(name_arg_ast.value, str):
+            return name_arg_ast.value
+        if isinstance(name_arg_ast, ast.Name):
+            # Level 2: walk the current namespace chain (current ns and all
+            # enclosing ones) looking for a tracked literal.  `name_literals`
+            # is keyed by the fully-qualified namespace where the literal was
+            # bound, so we have to traverse by namespace string rather than
+            # by `Scope` object (whose `.name` is "" for the module).
+            ns = self.get_node_of_current_namespace().get_name()
+            while True:
+                bucket = self.name_literals.get(ns, {})
+                if name_arg_ast.id in bucket:
+                    return bucket[name_arg_ast.id]
+                if "." not in ns:
+                    break
+                ns = ns.rsplit(".", 1)[0]
+            # Level 3: the Name might resolve to an imported binding.
+            # `get_value` returns the resolved Node (after import resolution
+            # within the visitor pass).  Look up its FQN's namespace in
+            # `name_literals`.
+            resolved = self.get_value(name_arg_ast.id)
+            if isinstance(resolved, Node) and resolved.namespace is not None:
+                bucket = self.name_literals.get(resolved.namespace, {})
+                if resolved.name in bucket:
+                    return bucket[resolved.name]
+        return None
+
+    def _maybe_register_setattr_call(self, call_ast):
+        """Recognize ``setattr(target, name, value)`` calls on
+        ``NAMESPACE_OBJECT``-flavored Nodes and register the implied
+        binding in *target*'s scope, mirroring ``e.k = v``.
+
+        Three structural preconditions:
+
+        1. ``call_ast.func`` resolves to FQN ``"builtins.setattr"`` (handles
+           aliased imports for free via scope-chain resolution).
+        2. ``target`` (first positional arg) resolves to a Node with
+           ``flavor=NAMESPACE_OBJECT`` (so a scope exists for it).
+        3. ``name`` (second positional arg) resolves to a string via the
+           three-level resolution in ``_resolve_setattr_name``.
+
+        On match: ``self.scopes[target_node.get_name()].defs[name] = visit(value)``.
+        On miss: no-op — same floor as the #127 module-level fallback.
+
+        Symmetric ``delattr`` is intentionally not handled: pyan is
+        flow-insensitive, and clearing bindings from a branch that doesn't
+        always execute would be wrong as often as right (see
+        ``visit_Delete`` for the analogous reasoning on ``del obj.attr``).
+        """
+        # Cheap structural gates first.  We're called from visit_Call on
+        # every Call in the analyzed source, so the gate ordering matters
+        # for analyzer cost: AST-shape checks are O(1), but FQN resolution
+        # involves scope-chain lookup and/or attribute resolution.
+        if len(call_ast.args) != 3 or call_ast.keywords:
+            return
+        if any(isinstance(a, ast.Starred) for a in call_ast.args):
+            return
+        target_arg, name_arg, value_arg = call_ast.args
+        # Precondition: target is a `Name` (the recognizer doesn't handle
+        # nested forms like ``setattr(get_obj(), ...)``).  Skip before
+        # attempting any expensive resolution.
+        if not isinstance(target_arg, ast.Name):
+            return
+        if not isinstance(call_ast.func, (ast.Name, ast.Attribute)):
+            return
+        # Precondition 1: func is builtins.setattr.
+        fqn = self._resolve_constructor_fqn(call_ast.func)
+        if fqn != "builtins.setattr":
+            return
+        # Precondition 2: target resolves to a NAMESPACE_OBJECT Node.
+        target_node = self.get_value(target_arg.id)
+        if not isinstance(target_node, Node) or target_node.flavor != Flavor.NAMESPACE_OBJECT:
+            return
+        # Precondition 3: name resolves to a string literal.
+        attr_name = self._resolve_setattr_name(name_arg)
+        if attr_name is None:
+            return
+        # Register the binding into target's scope.  set_attribute can't
+        # be used here — its API takes an Attribute AST node, which we
+        # don't have (the LHS *is* a Call, not an Attribute).
+        self._register_namespace_object_attr(target_node, attr_name, self.visit(value_arg))
+
     @staticmethod
     def _collect_target_names(target, names):
         """Collect all Name identifiers from an assignment target AST node."""
@@ -1841,8 +2164,8 @@ class CallGraphVisitor(ast.NodeVisitor):
         """Generic handler for binding forms. Inputs must be canonize_exprs()d."""
         captured = [self.visit(value) for value in values]
         if len(targets) == len(captured):
-            for tgt, val in zip(targets, captured, strict=False):
-                self._bind_target(tgt, val)
+            for tgt, val, val_ast in zip(targets, captured, values, strict=False):
+                self._bind_target(tgt, val, rhs_ast=val_ast)
         else:
             # Check for positional starred unpacking on LHS (e.g. a, b, *c = x, y, z, w).
             star_idx = None

--- a/pyan/anutils.py
+++ b/pyan/anutils.py
@@ -18,8 +18,32 @@ logger = logging.getLogger(__name__)
 # whether to emit an ambiguity advisory.
 _PROJECT_ROOT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
 
+# Built-in registry of namespace-constructor fully-qualified names.  When a
+# binding's RHS is ``Call(func=...)`` whose resolved import-origin matches one
+# of these, the LHS Node is upgraded to :data:`Flavor.NAMESPACE_OBJECT` and
+# its scope is populated with the call's keyword arguments.  See ``#129``.
+#
+# The registry is user-extensible via the CLI flag
+# ``--namespace-constructor FQN`` (and via the ``namespace_constructors``
+# kwarg on ``CallGraphVisitor`` / ``create_callgraph``).  If a constructor is
+# common enough to be worth bundling, please file an issue at
+# https://github.com/Technologicat/pyan/issues so it can be added here.
+#
+# ``unpythonic.env.env`` (canonical) and ``unpythonic.env`` (top-level
+# re-export — same name as the submodule, due to historical naming) are
+# both listed: pyan can only collapse them onto a single Node if
+# ``unpythonic``'s source tree is part of the analyzed set, which it isn't
+# for any application *using* unpythonic.
+NAMESPACE_CONSTRUCTORS = frozenset({
+    "unpythonic.env.env",
+    "unpythonic.env",
+    "types.SimpleNamespace",
+    "argparse.Namespace",
+})
+
 __all__ = [
     "ExecuteInInnerScope",
+    "NAMESPACE_CONSTRUCTORS",
     "Scope",
     "UnresolvedSuperCallError",
     "canonize_exprs",

--- a/pyan/main.py
+++ b/pyan/main.py
@@ -30,7 +30,7 @@ __all__ = [
 
 def _build_graph(filenames=None, root=None, sources=None, function=None, namespace=None,
                  max_iter=1000, direction="both", depth=None,
-                 logger=None, graph_options=None):
+                 logger=None, graph_options=None, namespace_constructors=None):
     """Analyze source files, optionally filter, and build a VisualGraph.
 
     If `sources` is given (source mode / sans-IO mode), it overrides `filenames` and `root`.
@@ -38,9 +38,11 @@ def _build_graph(filenames=None, root=None, sources=None, function=None, namespa
     Shared core of ``create_callgraph()`` and ``main()``.
     """
     if sources is not None:
-        v = CallGraphVisitor.from_sources(sources, logger=logger)
+        v = CallGraphVisitor.from_sources(sources, logger=logger,
+                                          namespace_constructors=namespace_constructors)
     else:
-        v = CallGraphVisitor(filenames, root=root, logger=logger)
+        v = CallGraphVisitor(filenames, root=root, logger=logger,
+                             namespace_constructors=namespace_constructors)
     if function or namespace:
         if function:
             function_name = function.split(".")[-1]
@@ -76,6 +78,7 @@ def create_callgraph(
     concentrate: bool = False,
     depth: int | None = None,
     exclude: list[str] | None = None,
+    namespace_constructors: list[str] | None = None,
     logger=None,
 ) -> str:
     """Create a call graph based on static code analysis.
@@ -145,6 +148,12 @@ def create_callgraph(
             separator match against the basename (e.g. ``"test_*.py"``);
             patterns with a separator match against the full path
             (e.g. ``"*/tests/*"``).
+        namespace_constructors: extra fully-qualified constructor names
+            to recognize as producing ``Flavor.NAMESPACE_OBJECT`` Nodes,
+            beyond the built-in registry (``unpythonic.env.env``,
+            ``types.SimpleNamespace``, ``argparse.Namespace``, …).  Each
+            entry is the canonical dotted import path
+            (e.g. ``"my.lib.MyNamespace"``).  See #129.
         logger: optional ``logging.Logger`` instance.
 
     Returns:
@@ -174,7 +183,8 @@ def create_callgraph(
     graph = _build_graph(filenames=filenames, root=root, sources=sources,
                          function=function, namespace=namespace,
                          max_iter=max_iter, direction=direction, depth=depth,
-                         logger=logger, graph_options=graph_options)
+                         logger=logger, graph_options=graph_options,
+                         namespace_constructors=namespace_constructors)
 
     stream = io.StringIO()
     dot_options = ["rankdir=" + rankdir, "ranksep=" + ranksep, "layout=" + layout]
@@ -459,6 +469,24 @@ def main(cli_args=None):
     )
 
     parser.add_argument(
+        "--namespace-constructor",
+        action="append",
+        default=[],
+        dest="namespace_constructors",
+        metavar="FQN",
+        help=(
+            "register an extra namespace-constructor FQN (e.g. "
+            "'mylib.MyNamespace'). When the rhs of an assignment is a call "
+            "to a registered constructor, the LHS is treated as a runtime "
+            "namespace value and its kwargs become attribute bindings, so "
+            "that external 'config.attr' access resolves to the kwarg's "
+            "target. Built-in: unpythonic.env.env, types.SimpleNamespace, "
+            "argparse.Namespace. Can be repeated, or comma-separated "
+            "(e.g. --namespace-constructor a.b,c.d). See #129."
+        ),
+    )
+
+    parser.add_argument(
         "--module-level",
         action="store_true",
         default=False,
@@ -536,10 +564,29 @@ def main(cli_args=None):
         except ValueError:
             parser.error(f"--depth must be an integer or 'max', got {known_args.depth!r}")
 
+    # Normalize --namespace-constructor: each occurrence may itself be
+    # comma-separated.  Empty list means "no extras"; only emit the nudge
+    # when the user actually supplied at least one entry.
+    extra_constructors = []
+    for raw in known_args.namespace_constructors:
+        for part in raw.split(","):
+            part = part.strip()
+            if part:
+                extra_constructors.append(part)
+    if extra_constructors:
+        sys.stderr.write(
+            "note: pyan recognises namespace constructors from a built-in "
+            "registry. If your constructor is reasonably common and not "
+            "yet recognised, please file an issue at "
+            "https://github.com/Technologicat/pyan/issues so it can be "
+            "added.\n"
+        )
+
     graph = _build_graph(filenames, root=root, function=known_args.function,
                          namespace=known_args.namespace,
                          direction=known_args.direction, depth=depth,
-                         logger=logger, graph_options=graph_options)
+                         logger=logger, graph_options=graph_options,
+                         namespace_constructors=extra_constructors)
 
     writer = None
     dot_options = [

--- a/pyan/node.py
+++ b/pyan/node.py
@@ -33,6 +33,7 @@ class Flavor(Enum):
     STATICMETHOD = "staticmethod"
     CLASSMETHOD = "classmethod"
     NAME = "name"  # Python name (e.g. "x" in "x = 42")
+    NAMESPACE_OBJECT = "namespace-object"  # runtime namespace value (env, SimpleNamespace, ...): a NAME with a populated scope listing its statically-visible attributes. Distinct from SCOPE (the structural bookkeeping marker for module/class/function scopes).
 
     # Flavors have a partial ordering in specificness of the information.
     #

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -208,6 +208,30 @@ class TestPyanCLI:
         captured = capsys.readouterr()
         assert "digraph G" in captured.out
 
+    def test_namespace_constructor_flag_emits_nudge(self, capsys):
+        """Supplying ``--namespace-constructor`` emits the one-shot stderr
+        nudge inviting the user to file an issue if their constructor is
+        common enough to be added to the built-in registry."""
+        pyan_main([FIXTURE, "--dot", "--namespace-constructor", "mylib.MyNS"])
+        captured = capsys.readouterr()
+        assert "namespace constructor" in captured.err
+        assert "github.com/Technologicat/pyan/issues" in captured.err
+
+    def test_namespace_constructor_flag_accepts_comma_separated(self, capsys):
+        """``--namespace-constructor a.b,c.d`` splits to two entries; a
+        single occurrence still triggers the nudge once."""
+        pyan_main([FIXTURE, "--dot", "--namespace-constructor", "a.b,c.d"])
+        captured = capsys.readouterr()
+        # Only one nudge regardless of how many comma-separated entries.
+        assert captured.err.count("github.com/Technologicat/pyan/issues") == 1
+
+    def test_namespace_constructor_flag_no_nudge_without_option(self, capsys):
+        """The nudge should not fire when ``--namespace-constructor`` is
+        not used."""
+        pyan_main([FIXTURE, "--dot"])
+        captured = capsys.readouterr()
+        assert "namespace constructor" not in captured.err
+
 
 # ---------------------------------------------------------------------------
 # __init__.py coverage

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -896,3 +896,230 @@ def test_visgraph_suppresses_edgeless_name_nodes():
     assert not any("UNUSED" in lab for lab in labels), (
         f"UNUSED has no uses edges and should be suppressed; saw {labels}"
     )
+
+
+# --- NAMESPACE_OBJECT (constructor-based namespace recognition, #129) ---
+
+def _namespace_object_node(visitor, fqn):
+    """Locate the NAMESPACE_OBJECT-flavored Node at *fqn*, or None."""
+    from pyan.node import Flavor
+    namespace, _, name = fqn.rpartition(".")
+    for n in visitor.nodes.get(name, []):
+        if n.namespace == namespace and n.flavor == Flavor.NAMESPACE_OBJECT:
+            return n
+    return None
+
+
+def _scope_defs(visitor, fqn):
+    """Return defs dict of the scope at *fqn*, or empty dict if absent."""
+    sc = visitor.scopes.get(fqn)
+    return sc.defs if sc else {}
+
+
+# Each of the four built-in constructors gets at least one fixture.
+
+def test_namespace_object_unpythonic_env_canonical_form():
+    """``from unpythonic.env import env; config = env(thingy=baa)`` —
+    canonical FQN ``"unpythonic.env.env"``."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig = env(thingy=baa)\n", "mymod"),
+    ])
+    obj = _namespace_object_node(v, "mymod.config")
+    assert obj is not None, "config should be a NAMESPACE_OBJECT Node"
+    assert "thingy" in _scope_defs(v, "mymod.config"), "kwarg 'thingy' should register in config's scope"
+
+
+def test_namespace_object_unpythonic_env_top_level_reexport():
+    """``from unpythonic import env; config = env(thingy=baa)`` —
+    top-level re-export FQN ``"unpythonic.env"`` (the module shadows
+    the class — historical naming)."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic import env\n\nconfig = env(thingy=baa)\n", "mymod"),
+    ])
+    obj = _namespace_object_node(v, "mymod.config")
+    assert obj is not None
+    assert "thingy" in _scope_defs(v, "mymod.config")
+
+
+def test_namespace_object_simplenamespace():
+    """``import types; ns = types.SimpleNamespace(thingy=baa)`` — Attribute
+    func, FQN reconstructed from the dotted AST path."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nimport types\n\nns = types.SimpleNamespace(thingy=baa)\n", "mymod"),
+    ])
+    obj = _namespace_object_node(v, "mymod.ns")
+    assert obj is not None
+    assert "thingy" in _scope_defs(v, "mymod.ns")
+
+
+def test_namespace_object_argparse_namespace():
+    """``import argparse; cfg = argparse.Namespace(thingy=baa)``."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nimport argparse\n\ncfg = argparse.Namespace(thingy=baa)\n", "mymod"),
+    ])
+    obj = _namespace_object_node(v, "mymod.cfg")
+    assert obj is not None
+    assert "thingy" in _scope_defs(v, "mymod.cfg")
+
+
+# Each of the four binding sites.
+
+def test_namespace_object_recognized_in_annotated_assign():
+    """``config: Env = env(...)`` — AnnAssign path."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig: env = env(thingy=baa)\n", "mymod"),
+    ])
+    assert _namespace_object_node(v, "mymod.config") is not None
+
+
+def test_namespace_object_recognized_in_walrus():
+    """``(config := env(...))`` — NamedExpr path."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\n_ = (config := env(thingy=baa))\n", "mymod"),
+    ])
+    assert _namespace_object_node(v, "mymod.config") is not None
+
+
+def test_namespace_object_recognized_in_with_statement():
+    """``with env(...) as config:`` — `_visit_with` routes through
+    `analyze_binding`, same recognition path."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nwith env(thingy=baa) as config:\n    pass\n", "mymod"),
+    ])
+    # In a with-statement at module scope, the binding still creates a
+    # module-level NAME Node that gets upgraded to NAMESPACE_OBJECT.
+    assert _namespace_object_node(v, "mymod.config") is not None
+
+
+# Cross-module attribute resolution — the headline use case.
+
+def test_namespace_object_cross_module_attr_resolves():
+    """External ``config.thingy`` resolves to the kwarg's target Node,
+    bypassing #127's module-level fallback entirely."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig = env(thingy=baa)\n", "lib"),
+        ("from lib import config\n\ndef use():\n    return config.thingy\n", "consumer"),
+    ])
+    use_uses = {n.get_name() for n in v.uses_edges.get(v.get_node("consumer", "use"), set())}
+    assert "lib.baa" in use_uses, f"config.thingy should resolve to lib.baa; saw {use_uses}"
+
+
+# Staged form: point 4 in the design brief.
+
+def test_namespace_object_attribute_write_after_construction():
+    """``config = env(); config.a = baa`` — the attribute write goes
+    through ``_bind_target``'s Attribute branch and ``set_attribute``,
+    which writes into the NAMESPACE_OBJECT's scope (created at
+    construction time, even when no kwargs were passed)."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig = env()\nconfig.a = baa\n", "mymod"),
+    ])
+    assert _namespace_object_node(v, "mymod.config") is not None
+    assert "a" in _scope_defs(v, "mymod.config"), "later attribute write should populate the scope"
+
+
+# setattr — three levels.
+
+def test_namespace_object_setattr_level1_literal_string():
+    """``setattr(config, "a", baa)`` — literal-string name."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig = env()\nsetattr(config, 'a', baa)\n", "mymod"),
+    ])
+    assert "a" in _scope_defs(v, "mymod.config")
+
+
+def test_namespace_object_setattr_level2_scope_local_literal():
+    """``k = "a"; setattr(config, k, baa)`` — name-bound literal in same
+    scope. Module-level binding chain only (function-local literals not
+    tracked, by design — see ``_maybe_register_name_literal``)."""
+    v = CallGraphVisitor.from_sources([
+        ("def baa():\n    pass\n\nfrom unpythonic.env import env\n\nconfig = env()\nKEY = 'a'\nsetattr(config, KEY, baa)\n", "mymod"),
+    ])
+    assert "a" in _scope_defs(v, "mymod.config")
+
+
+def test_namespace_object_setattr_level3_cross_module_imported_literal():
+    """``from constants import KEY; setattr(config, KEY, baa)`` — KEY
+    traces back through an import to a string literal in another module."""
+    v = CallGraphVisitor.from_sources([
+        ("KEY = 'a'\n", "constants"),
+        (
+            "def baa():\n    pass\n\n"
+            "from unpythonic.env import env\n"
+            "from constants import KEY\n\n"
+            "config = env()\n"
+            "setattr(config, KEY, baa)\n",
+            "mymod",
+        ),
+    ])
+    assert "a" in _scope_defs(v, "mymod.config")
+
+
+def test_namespace_object_setattr_dynamic_key_is_no_op():
+    """``for k in keys: setattr(config, k, baa)`` — k is loop-bound and
+    not statically a string literal. Recognition gracefully no-ops; no
+    spurious bindings are registered."""
+    v = CallGraphVisitor.from_sources([
+        (
+            "def baa():\n    pass\n\n"
+            "from unpythonic.env import env\n\n"
+            "config = env()\n"
+            "for k in ('a', 'b'):\n"
+            "    setattr(config, k, baa)\n",
+            "mymod",
+        ),
+    ])
+    # The constructor recognition still creates the NAMESPACE_OBJECT,
+    # but no individual kwarg names get registered from the loop.
+    obj = _namespace_object_node(v, "mymod.config")
+    assert obj is not None
+    defs = _scope_defs(v, "mymod.config")
+    assert "a" not in defs and "b" not in defs
+
+
+# User-extensible registry.
+
+def test_user_extensible_namespace_constructor():
+    """``namespace_constructors=["mylib.MyNS"]`` extends the registry."""
+    v = CallGraphVisitor.from_sources(
+        [(
+            "def baa():\n    pass\n\n"
+            "from mylib import MyNS\n\n"
+            "config = MyNS(thingy=baa)\n",
+            "mymod",
+        )],
+        namespace_constructors=["mylib.MyNS"],
+    )
+    obj = _namespace_object_node(v, "mymod.config")
+    assert obj is not None
+    assert "thingy" in _scope_defs(v, "mymod.config")
+
+
+# Negative: don't over-fire.
+
+def test_factory_returned_namespace_not_recognized():
+    """``config = make_config()`` where ``make_config`` is a regular
+    function — not in the registry, so no upgrade. Falls through to
+    #127's module-level fallback as the right floor."""
+    v = CallGraphVisitor.from_sources([
+        (
+            "def baa():\n    pass\n\n"
+            "def make_config():\n    return None\n\n"
+            "config = make_config()\n",
+            "mymod",
+        ),
+    ])
+    assert _namespace_object_node(v, "mymod.config") is None
+
+
+def test_unrecognized_constructor_no_op():
+    """Calling a non-registered constructor doesn't accidentally upgrade."""
+    v = CallGraphVisitor.from_sources([
+        (
+            "def baa():\n    pass\n\n"
+            "class MyClass:\n    pass\n\n"
+            "config = MyClass()\n",
+            "mymod",
+        ),
+    ])
+    assert _namespace_object_node(v, "mymod.config") is None


### PR DESCRIPTION
Closes #129. Layered on top of the [prequisite](https://github.com/Technologicat/substrate-independent/blob/main/glossary.md#prequisite) (#130, already on master): every module-level binding has an addressable NAME Node, so this PR is now genuinely a small overlay — recognise the constructor, upgrade the LHS flavor, populate the scope.

## What it does

When the rhs of a binding resolves to a known namespace constructor, the LHS Node is upgraded from `Flavor.NAME` to `Flavor.NAMESPACE_OBJECT` and its scope is populated with the call's keyword arguments. External `config.thingy` access then resolves directly to whatever was passed as `thingy=`, bypassing #127's module-level fallback entirely.

**Built-in registry** (`NAMESPACE_CONSTRUCTORS` in `anutils.py`):
- `unpythonic.env.env` (canonical)
- `unpythonic.env` (top-level re-export — same name as the submodule due to historical naming; both forms must be in the registry, since pyan can only collapse them onto a single Node when `unpythonic`'s source tree is part of the analyzed set)
- `types.SimpleNamespace`
- `argparse.Namespace`

**User-extensible** via the `namespace_constructors` kwarg on `CallGraphVisitor` / `create_callgraph`, and via the CLI:

```bash
pyan3 src/ --dot --namespace-constructor mylib.MyNamespace
```

Repeatable, or comma-separated. A one-shot stderr nudge fires when the option is supplied, inviting the user to file an issue if their constructor is reasonably common — so the built-in registry can grow from observed real-world use.

## Recognition coverage

**Binding sites — all four:**
- `config = env(...)` (Assign)
- `config: Env = env(...)` (AnnAssign)
- `(config := env(...))` (NamedExpr / walrus)
- `with env(...) as config:` (context manager)

**Staged form** `config = env(); config.a = baa` — covered for free: the construction site creates an empty scope for the NAMESPACE_OBJECT, and the later attribute write goes through the existing `set_attribute` machinery into that scope.

**`setattr(target, name, value)`** writes — three concentric levels of static knowability for *name*:
1. **Level 1** — literal string `Constant(value=str)`.
2. **Level 2** — `Name(id=k)` where `k` is bound to a string literal in any namespace reachable from the call site.
3. **Level 3** — `Name(id=k)` where `k` resolves through an import to a string literal in another analyzed module.

Genuinely dynamic forms (loop variables, function-returned strings) remain out of scope — that's data-flow analysis, deliberately outside a static analyzer's lane. Symmetric `delattr` is not handled, for the same reason `visit_Delete` doesn't clear bindings on `del obj.attr`: clearing in a branch that doesn't always execute would be wrong as often as right.

## Smoke test

Verified against Raven Visualizer source — `app_state.dataset` and similar accesses now resolve to the specific `app_state` env's kwarg targets, matching what the issue described as the headline case.

## Tests

- 16 new tests in `test_features.py` covering each constructor, each binding site, cross-module attribute resolution, the staged form, all three setattr levels plus a dynamic-key negative, the user-extensible registry, and the factory-returned negative.
- 3 new CLI tests in `test_coverage.py` for the `--namespace-constructor` flag and the one-shot stderr nudge.
- 322 passing locally on Python 3.14, ruff clean.

## Design notes

[`briefs/namespace-objects-brief.md`](briefs/namespace-objects-brief.md) — full design rationale, the four levels, the why-not list (factory-returned, splat, genuinely dynamic).

## Test plan

- [x] Full test suite passes locally on Python 3.14 (322/322).
- [x] Ruff clean.
- [x] Smoke test against Raven Visualizer source.
- [ ] CI matrix (3.10–3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)